### PR TITLE
Breaking change/multi intent type support

### DIFF
--- a/example/example2.html
+++ b/example/example2.html
@@ -22,7 +22,7 @@
           <stripe-payment-sheet
             publishable-key="pk_test_xxxxx"
             show-label="false"
-            payment-intent-client-secret="pi-xxxxxx"
+            intent-client-secret="pi-xxxxxx"
             should-use-default-form-submit-action="false"
           ></stripe-payment-sheet>
       </stripe-element-modal>

--- a/example/index.html
+++ b/example/index.html
@@ -32,7 +32,7 @@
                         <br/>
                         <code>stripe payment_intents create --amount=100 --currency=jpy | jq .client_secret -r</code>
                     </p>
-                    <input name="payment-intent-client-secret" type="text" />
+                    <input name="intent-client-secret" type="text" />
                 </label>
             </fieldset>
             <button type="submit">Launch</button>
@@ -65,7 +65,7 @@
                 errorMessage.innerText = 'Stripe Publishable API Key is required'
                 return
             }
-            const paymentIntentClientSecret = document['open-modal-form']['payment-intent-client-secret'].value
+            const paymentIntentClientSecret = document['open-modal-form']['intent-client-secret'].value
             if (!paymentIntentClientSecret) {
                 errorMessage.innerText = 'Payment Intent Client Secret is required'
                 return
@@ -110,7 +110,7 @@
             /**
              * Set the payment intent client secret
              **/
-            stripeElement.setAttribute('payment-intent-client-secret', paymentIntentClientSecret)
+            stripeElement.setAttribute('intent-client-secret', paymentIntentClientSecret)
             stripeElement.setAttribute('payment-request-button', true)
 
             /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe-elements/stripe-elements",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Web component of Stripe elements",
   "main": "dist/index.cjs.js",
   "module": "dist/custom-elements/index.js",

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ https://github.com/stripe-elements/stripe-elements/blob/main/src/components/stri
           <stripe-payment-sheet
             publishable-key="pk_test_xxxxx"
             show-label="false"
-            payment-intent-client-secret="pi-xxxxxx"
+            intent-client-secret="pi-xxxxxx"
             should-use-default-form-submit-action="false"
           ></stripe-payment-sheet>
       </stripe-element-modal>
@@ -128,7 +128,7 @@ https://github.com/stripe-elements/stripe-elements/blob/main/src/components/stri
             /**
              * Set the payment intent client secret
              **/
-            stripeElement.setAttribute('payment-intent-client-secret', paymentIntentClientSecret)
+            stripeElement.setAttribute('intent-client-secret', paymentIntentClientSecret)
 
             /**
              * Disable default form submit event

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,8 +5,8 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { FormSubmitEvent, FormSubmitHandler, PaymentRequestButtonOption, PaymentRequestPaymentMethodEventHandler, PaymentRequestShippingAddressEventHandler, PaymentRequestShippingOptionEventHandler, ProgressStatus, StripeDidLoadedHandler, StripeLoadedEvent } from "./interfaces";
-import { PaymentIntentResult, PaymentRequestOptions } from "@stripe/stripe-js";
+import { DefaultFormSubmitResult, FormSubmitEvent, FormSubmitHandler, IntentType, PaymentRequestButtonOption, PaymentRequestPaymentMethodEventHandler, PaymentRequestShippingAddressEventHandler, PaymentRequestShippingOptionEventHandler, ProgressStatus, StripeDidLoadedHandler, StripeLoadedEvent } from "./interfaces";
+import { PaymentRequestOptions } from "@stripe/stripe-js";
 export namespace Components {
     interface StripeElementModal {
         /**
@@ -86,6 +86,10 @@ export namespace Components {
          */
         "intentClientSecret"?: string;
         /**
+          * Default submit handle type. If you want to use `setupIntent`, should update this attribute.
+         */
+        "intentType": IntentType;
+        /**
           * Your Stripe publishable API key.
          */
         "publishableKey": string;
@@ -131,10 +135,15 @@ export namespace Components {
         "handleSubmit": FormSubmitHandler;
         /**
           * The client secret from paymentIntent.create response
-          * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.setAttribute('payment-intent-client-secret', 'dummy')   }) ```
-          * @example ``` <stripe-card-element payment-intent-client-secret="dummy" /> ```
+          * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.setAttribute('intent-client-secret', 'dummy')   }) ```
+          * @example ``` <stripe-card-element intent-client-secret="dummy" /> ```
          */
         "intentClientSecret"?: string;
+        /**
+          * Default submit handle type. If you want to use `setupIntent`, should update this attribute.
+          * @example ``` <stripe-payment-sheet-modal intent-type="setup" /> ```
+         */
+        "intentType": IntentType;
         /**
           * Modal state. If true, the modal will open
          */
@@ -250,10 +259,14 @@ declare namespace LocalJSX {
          */
         "intentClientSecret"?: string;
         /**
+          * Default submit handle type. If you want to use `setupIntent`, should update this attribute.
+         */
+        "intentType"?: IntentType;
+        /**
           * Recieve the result of defaultFormSubmit event
           * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.addEventListener('defaultFormSubmitResult', async ({detail}) => {       if (detail instanceof Error) {         console.error(detail)       } else {         console.log(detail)       }     })   })
          */
-        "onDefaultFormSubmitResult"?: (event: CustomEvent<PaymentIntentResult | Error>) => void;
+        "onDefaultFormSubmitResult"?: (event: CustomEvent<DefaultFormSubmitResult>) => void;
         /**
           * Form submit event
           * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement       .addEventListener('formSubmit', async props => {         const {           detail: { stripe, cardNumber, event },         } = props;         const result = await stripe.createPaymentMethod({           type: 'card',           card: cardNumber,         });         console.log(result);       })   })
@@ -289,10 +302,15 @@ declare namespace LocalJSX {
         "handleSubmit"?: FormSubmitHandler;
         /**
           * The client secret from paymentIntent.create response
-          * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.setAttribute('payment-intent-client-secret', 'dummy')   }) ```
-          * @example ``` <stripe-card-element payment-intent-client-secret="dummy" /> ```
+          * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.setAttribute('intent-client-secret', 'dummy')   }) ```
+          * @example ``` <stripe-card-element intent-client-secret="dummy" /> ```
          */
         "intentClientSecret"?: string;
+        /**
+          * Default submit handle type. If you want to use `setupIntent`, should update this attribute.
+          * @example ``` <stripe-payment-sheet-modal intent-type="setup" /> ```
+         */
+        "intentType"?: IntentType;
         "onClosed"?: (event: CustomEvent<any>) => void;
         /**
           * Modal state. If true, the modal will open

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -81,10 +81,10 @@ export namespace Components {
         "initStripe": (publishableKey: string) => Promise<void>;
         /**
           * The client secret from paymentIntent.create response
-          * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.setAttribute('payment-intent-client-secret', 'dummy')   }) ```
-          * @example ``` <stripe-card-element payment-intent-client-secret="dummy" /> ```
+          * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.setAttribute('intent-client-secret', 'dummy')   }) ```
+          * @example ``` <stripe-card-element intent-client-secret="dummy" /> ```
          */
-        "paymentIntentClientSecret"?: string;
+        "intentClientSecret"?: string;
         /**
           * Your Stripe publishable API key.
          */
@@ -130,15 +130,15 @@ export namespace Components {
          */
         "handleSubmit": FormSubmitHandler;
         /**
-          * Modal state. If true, the modal will open
-         */
-        "open": boolean;
-        /**
           * The client secret from paymentIntent.create response
           * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.setAttribute('payment-intent-client-secret', 'dummy')   }) ```
           * @example ``` <stripe-card-element payment-intent-client-secret="dummy" /> ```
          */
-        "paymentIntentClientSecret"?: string;
+        "intentClientSecret"?: string;
+        /**
+          * Modal state. If true, the modal will open
+         */
+        "open": boolean;
         "present": () => Promise<unknown>;
         /**
           * Your Stripe publishable API key.
@@ -244,6 +244,12 @@ declare namespace LocalJSX {
          */
         "handleSubmit"?: FormSubmitHandler;
         /**
+          * The client secret from paymentIntent.create response
+          * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.setAttribute('intent-client-secret', 'dummy')   }) ```
+          * @example ``` <stripe-card-element intent-client-secret="dummy" /> ```
+         */
+        "intentClientSecret"?: string;
+        /**
           * Recieve the result of defaultFormSubmit event
           * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.addEventListener('defaultFormSubmitResult', async ({detail}) => {       if (detail instanceof Error) {         console.error(detail)       } else {         console.log(detail)       }     })   })
          */
@@ -258,12 +264,6 @@ declare namespace LocalJSX {
           * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement      .addEventListener('stripeLoaded', async ({ detail: {stripe} }) => {       stripe         .createSource({           type: 'ideal',           amount: 1099,           currency: 'eur',           owner: {             name: 'Jenny Rosen',           },           redirect: {             return_url: 'https://shop.example.com/crtA6B28E1',           },         })         .then(function(result) {           // Handle result.error or result.source         });       });   }) ```
          */
         "onStripeLoaded"?: (event: CustomEvent<StripeLoadedEvent>) => void;
-        /**
-          * The client secret from paymentIntent.create response
-          * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.setAttribute('payment-intent-client-secret', 'dummy')   }) ```
-          * @example ``` <stripe-card-element payment-intent-client-secret="dummy" /> ```
-         */
-        "paymentIntentClientSecret"?: string;
         /**
           * Your Stripe publishable API key.
          */
@@ -287,17 +287,17 @@ declare namespace LocalJSX {
           * Form submit event handler
          */
         "handleSubmit"?: FormSubmitHandler;
-        "onClosed"?: (event: CustomEvent<any>) => void;
-        /**
-          * Modal state. If true, the modal will open
-         */
-        "open"?: boolean;
         /**
           * The client secret from paymentIntent.create response
           * @example ``` const stripeElement = document.createElement('stripe-card-element'); customElements  .whenDefined('stripe-card-element')  .then(() => {     stripeElement.setAttribute('payment-intent-client-secret', 'dummy')   }) ```
           * @example ``` <stripe-card-element payment-intent-client-secret="dummy" /> ```
          */
-        "paymentIntentClientSecret"?: string;
+        "intentClientSecret"?: string;
+        "onClosed"?: (event: CustomEvent<any>) => void;
+        /**
+          * Modal state. If true, the modal will open
+         */
+        "open"?: boolean;
         /**
           * Your Stripe publishable API key.
          */

--- a/src/components/stripe-payment-sheet-modal/stripe-payment-sheet-modal.tsx
+++ b/src/components/stripe-payment-sheet-modal/stripe-payment-sheet-modal.tsx
@@ -40,7 +40,7 @@ export class StripePaymentSheetModal {
    * <stripe-card-element payment-intent-client-secret="dummy" />
    * ```
    */
-  @Prop() paymentIntentClientSecret?: string;
+  @Prop() intentClientSecret?: string;
 
   /**
    * The component will provide a function to call the `stripe.confirmCardPayment`API.
@@ -145,7 +145,7 @@ export class StripePaymentSheetModal {
         <stripe-payment-sheet
           showLabel={this.showLabel}
           publishableKey={this.publishableKey}
-          paymentIntentClientSecret={this.paymentIntentClientSecret}
+          intentClientSecret={this.intentClientSecret}
           shouldUseDefaultFormSubmitAction={this.shouldUseDefaultFormSubmitAction}
           handleSubmit={this.handleSubmit}
           stripeDidLoaded={this.stripeDidLoaded}

--- a/src/components/stripe-payment-sheet-modal/stripe-payment-sheet-modal.tsx
+++ b/src/components/stripe-payment-sheet-modal/stripe-payment-sheet-modal.tsx
@@ -1,7 +1,7 @@
 import { Component, Prop, h, Method, Element, Event, EventEmitter } from '@stencil/core';
 import {
   StripeDidLoadedHandler, FormSubmitHandler, ProgressStatus,
-  PaymentRequestButtonOption,
+  PaymentRequestButtonOption, IntentType,
  } from '../../interfaces';
 
 @Component({
@@ -31,13 +31,13 @@ export class StripePaymentSheetModal {
    * customElements
    *  .whenDefined('stripe-card-element')
    *  .then(() => {
-   *     stripeElement.setAttribute('payment-intent-client-secret', 'dummy')
+   *     stripeElement.setAttribute('intent-client-secret', 'dummy')
    *   })
    * ```
    *
    * @example
    * ```
-   * <stripe-card-element payment-intent-client-secret="dummy" />
+   * <stripe-card-element intent-client-secret="dummy" />
    * ```
    */
   @Prop() intentClientSecret?: string;
@@ -48,6 +48,16 @@ export class StripePaymentSheetModal {
    * And listen the 'formSubmit' event on the element
    */
   @Prop() shouldUseDefaultFormSubmitAction = true;
+
+  /**
+   * Default submit handle type.
+   * If you want to use `setupIntent`, should update this attribute.
+   * @example
+   * ```
+   * <stripe-payment-sheet-modal intent-type="setup" />
+   * ```
+   */
+  @Prop() intentType: IntentType = 'payment'
 
   /**
    * Form submit event handler
@@ -149,6 +159,7 @@ export class StripePaymentSheetModal {
           shouldUseDefaultFormSubmitAction={this.shouldUseDefaultFormSubmitAction}
           handleSubmit={this.handleSubmit}
           stripeDidLoaded={this.stripeDidLoaded}
+          intentType={this.intentType}
         ></stripe-payment-sheet>
       </stripe-element-modal>
     );

--- a/src/components/stripe-payment-sheet-modal/test/__snapshots__/stripe-payment-sheet-modal.spec.tsx.snap
+++ b/src/components/stripe-payment-sheet-modal/test/__snapshots__/stripe-payment-sheet-modal.spec.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`stripe-payment-sheet-modal renders 1`] = `
+<stripe-payment-sheet-modal>
+  <stripe-element-modal showclosebutton="">
+    <stripe-payment-sheet intenttype="payment" shouldusedefaultformsubmitaction=""></stripe-payment-sheet>
+  </stripe-element-modal>
+</stripe-payment-sheet-modal>
+`;

--- a/src/components/stripe-payment-sheet-modal/test/stripe-payment-sheet-modal.spec.tsx
+++ b/src/components/stripe-payment-sheet-modal/test/stripe-payment-sheet-modal.spec.tsx
@@ -8,12 +8,6 @@ describe('stripe-payment-sheet-modal', () => {
       html: `<stripe-payment-sheet-modal></stripe-payment-sheet-modal>`,
     });
 
-    expect(page.root).toEqualHtml(`
-      <stripe-payment-sheet-modal>
-        <stripe-element-modal showclosebutton="">
-            <stripe-payment-sheet shouldusedefaultformsubmitaction=""></stripe-payment-sheet>
-        </stripe-element-modal>
-      </stripe-payment-sheet-modal>
-    `);
+    expect(page.root).toMatchSnapshot()
   });
 });

--- a/src/components/stripe-payment-sheet/stripe-payment-sheet.tsx
+++ b/src/components/stripe-payment-sheet/stripe-payment-sheet.tsx
@@ -155,16 +155,16 @@ export class StripePaymentSheet {
    * customElements
    *  .whenDefined('stripe-card-element')
    *  .then(() => {
-   *     stripeElement.setAttribute('payment-intent-client-secret', 'dummy')
+   *     stripeElement.setAttribute('intent-client-secret', 'dummy')
    *   })
    * ```
    *
    * @example
    * ```
-   * <stripe-card-element payment-intent-client-secret="dummy" />
+   * <stripe-card-element intent-client-secret="dummy" />
    * ```
    */
-  @Prop() paymentIntentClientSecret?: string;
+  @Prop() intentClientSecret?: string;
 
   /**
    * The component will provide a function to call the `stripe.confirmCardPayment`API.
@@ -320,10 +320,10 @@ export class StripePaymentSheet {
    * @param event
    * @param param1
    */
-  private async defaultFormSubmitAction(event: Event, { stripe, cardNumber, paymentIntentClientSecret }: FormSubmitEvent) {
+  private async defaultFormSubmitAction(event: Event, { stripe, cardNumber, intentClientSecret }: FormSubmitEvent) {
     event.preventDefault();
     try {
-      const result = await stripe.confirmCardPayment(paymentIntentClientSecret, {
+      const result = await stripe.confirmCardPayment(intentClientSecret, {
         payment_method: {
           card: cardNumber,
         },
@@ -378,14 +378,14 @@ export class StripePaymentSheet {
     this.cardCVC.on('change', handleCardError);
 
     document.getElementById('stripe-card-element').addEventListener('submit', async e => {
-      const { cardCVC, cardExpiry, cardNumber, stripe, paymentIntentClientSecret } = this;
-      const submitEventProps: FormSubmitEvent = { cardCVC, cardExpiry, cardNumber, stripe, paymentIntentClientSecret };
+      const { cardCVC, cardExpiry, cardNumber, stripe, intentClientSecret } = this;
+      const submitEventProps: FormSubmitEvent = { cardCVC, cardExpiry, cardNumber, stripe, intentClientSecret };
 
       this.progress = 'loading';
       try {
         if (this.handleSubmit) {
           await this.handleSubmit(e, submitEventProps);
-        } else if (this.shouldUseDefaultFormSubmitAction === true && paymentIntentClientSecret) {
+        } else if (this.shouldUseDefaultFormSubmitAction === true && intentClientSecret) {
           await this.defaultFormSubmitAction(e, submitEventProps);
         } else {
           e.preventDefault();

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,6 +7,8 @@ import {
   PaymentRequestShippingOptionEvent,
   PaymentRequestShippingAddressEvent,
   PaymentRequestOptions,
+  PaymentIntentResult,
+  SetupIntentResult,
 } from '@stripe/stripe-js';
 
 /**
@@ -55,3 +57,9 @@ export type PaymentRequestButtonOption = PaymentRequestOptions & {
   paymentRequestShippingAddressChangeHandler?: PaymentRequestShippingAddressEventHandler;
   paymentRequestShippingOptionChangeHandler?: PaymentRequestShippingOptionEventHandler; 
 }
+
+/**
+ * Stripe XXXIntent types
+ */
+export type IntentType = 'setup' | 'payment'
+export type DefaultFormSubmitResult = Error | PaymentIntentResult | SetupIntentResult

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,7 +17,7 @@ export type FormSubmitEvent = {
   cardNumber: StripeCardNumberElement;
   cardExpiry: StripeCardExpiryElement;
   cardCVC: StripeCardCvcElement;
-  paymentIntentClientSecret?: string;
+  intentClientSecret?: string;
 };
 /**
  * Handler function of the `formSubmit` event


### PR DESCRIPTION
## Use default submit handler to process Payment Intent

```html
<stripe-payment-sheet
  intent-client-secret="pi_xxxx"
  intent-type="payment"
></stripe-payment-sheet>
```

## Use default submit handler to process Setup Intent

```html
<stripe-payment-sheet
  intent-client-secret="si_xxxx"
  intent-type="setup"
></stripe-payment-sheet>
```