### PR TITLE
Send plugin AppInfo

### DIFF
--- a/src/components/stripe-payment-sheet/stripe-payment-sheet.tsx
+++ b/src/components/stripe-payment-sheet/stripe-payment-sheet.tsx
@@ -55,6 +55,9 @@ export class StripePayment {
     loadStripe(publishableKey)
       .then(stripe => {
         this.loadStripeStatus = 'success';
+        stripe.setAppInfo({
+          name: "@stripe-elements/stripe-elements"
+        });
         this.stripe = stripe;
         return;
       })
@@ -482,7 +485,7 @@ export class StripePayment {
           stripePaymentRequestElement
             .setPaymentRequestShippingOptionEventHandler(paymentRequestShippingOptionChangeHandler)
         }
-   
+
         if (paymentRequestShippingAddressChangeHandler) {
           stripePaymentRequestElement.
             setPaymentRequestShippingAddressEventHandler(paymentRequestShippingAddressChangeHandler)
@@ -500,7 +503,7 @@ export class StripePayment {
     }
 
     const disabled = this.progress === 'loading';
-    
+
 
     return (
       <div class="stripe-payment-sheet-wrap">


### PR DESCRIPTION
Hello! This PR is part of the one I filed on [your other project](https://github.com/capacitor-community/stripe/pull/108). I noticed that your plugin isn't sending a user-agent [via the `AppInfo` field](https://stripe.com/docs/building-plugins). Would you mind if I changed this? It would help us provide better support for our users when they call in with integration questions.

Thanks!