### PR TITLE
Upgrade Node.js version from 20 to 22

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,5 +4,5 @@
   publish = "dist"
 
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "22"
 


### PR DESCRIPTION
## Summary
Updates the Node.js runtime version used for Netlify builds from version 20 to version 22.

## Changes
- Updated `NODE_VERSION` in `netlify.toml` from `"20"` to `"22"`

## Details
This change ensures that the Netlify build environment uses Node.js 22, which includes the latest features, performance improvements, and security updates available in that LTS/stable release.

https://claude.ai/code/session_0112R11YELAFkSBkVnwPC3mU