### PR TITLE
refactor: make boolean conditions explicit across components, services and utils

### DIFF
--- a/src/components/stripe-address-element/stripe-address-element.scss
+++ b/src/components/stripe-address-element/stripe-address-element.scss
@@ -1,6 +1,10 @@
 @use '../../style/theme';
 @use '../../style/rest';
 
+// NOTE: `stripe-payment-sheet-wrap` is a legacy CSS class kept for backward
+// compatibility (leftover from a former component name). It is part of the public
+// DOM contract — consumers may target it in their own stylesheets — so this selector
+// and the matching className in stripe-address-element.tsx must be kept in sync.
 .stripe-payment-sheet-wrap {
   @include rest.rest;
 

--- a/src/components/stripe-address-element/stripe-address-element.tsx
+++ b/src/components/stripe-address-element/stripe-address-element.tsx
@@ -170,7 +170,7 @@ export class StripeAddressElement {
   }> {
     const addressElement = this.addressElementManager.getElement();
 
-    if (!addressElement) {
+    if (addressElement == null) {
       throw new Error('Address element not initialized');
     }
 
@@ -188,11 +188,11 @@ export class StripeAddressElement {
   updatePublishableKey(publishableKey: string) {
     const options: InitStripeOptions = {};
 
-    if (this.stripeAccount) {
+    if (this.stripeAccount != null && this.stripeAccount !== '') {
       options.stripeAccount = this.stripeAccount;
     }
 
-    this.initStripe(publishableKey, Object.keys(options).length ? options : undefined);
+    this.initStripe(publishableKey, Object.keys(options).length > 0 ? options : undefined);
   }
 
   /**
@@ -205,7 +205,7 @@ export class StripeAddressElement {
   updateStripeAccountId(stripeAccount: string) {
     const publishableKey = this.stripeService.state.publishableKey || this.publishableKey;
 
-    if (!publishableKey) {
+    if (publishableKey == null || publishableKey === '') {
       return;
     }
 
@@ -273,7 +273,7 @@ export class StripeAddressElement {
       stripe: this.stripeService.getStripe(),
     };
 
-    if (this.stripeDidLoaded) {
+    if (this.stripeDidLoaded != null) {
       this.stripeDidLoaded(event);
     }
 
@@ -307,7 +307,7 @@ export class StripeAddressElement {
   }
 
   componentWillRender() {
-    if (!this.stripeService.state.publishableKey) {
+    if (this.stripeService.state.publishableKey == null || this.stripeService.state.publishableKey === '') {
       return;
     }
 
@@ -325,7 +325,7 @@ export class StripeAddressElement {
     this.stripeService = serviceFactory.createStripeService();
     this.addressElementManager = serviceFactory.createAddressElementManager(this.stripeService);
 
-    if (this.publishableKey) {
+    if (this.publishableKey != null && this.publishableKey !== '') {
       this.initStripe(this.publishableKey, {
         stripeAccount: this.stripeAccount,
       });
@@ -341,7 +341,7 @@ export class StripeAddressElement {
       mode: this.mode,
     };
 
-    if (this.defaultCountry) {
+    if (this.defaultCountry != null && this.defaultCountry !== '') {
       addressOptions.defaultValues = {
         address: {
           country: this.defaultCountry,
@@ -359,13 +359,13 @@ export class StripeAddressElement {
     // Add form submit listener scoped to this component instance
     const formElement = this.el.querySelector('#stripe-address-element-form');
 
-    if (!formElement) {
+    if (formElement == null) {
       console.error('Form element #stripe-address-element-form not found');
       return;
     }
 
     // Remove previous listener if it exists to prevent duplicate submissions
-    if (this.formSubmitListener) {
+    if (this.formSubmitListener != null) {
       formElement.removeEventListener('submit', this.formSubmitListener);
     }
 
@@ -375,7 +375,7 @@ export class StripeAddressElement {
 
       const addressElement = this.addressElementManager.getElement();
 
-      if (!addressElement) {
+      if (addressElement == null) {
         console.error('Address element not initialized');
         return;
       }
@@ -385,13 +385,13 @@ export class StripeAddressElement {
       try {
         const addressValue = await this.getValue();
 
-        if (this.handleSubmit) {
+        if (this.handleSubmit != null) {
           await this.handleSubmit(e, { address: addressValue });
         }
 
         await this.formSubmitEventHandler();
 
-        if (this.handleSubmit) {
+        if (this.handleSubmit != null) {
           this.progress = 'success';
         }
       } catch (error) {
@@ -411,10 +411,10 @@ export class StripeAddressElement {
 
   disconnectedCallback() {
     // Remove form submit listener
-    if (this.formSubmitListener) {
+    if (this.formSubmitListener != null) {
       const formElement = this.el.querySelector('#stripe-address-element-form');
 
-      if (formElement) {
+      if (formElement != null) {
         formElement.removeEventListener('submit', this.formSubmitListener);
       }
 
@@ -434,6 +434,10 @@ export class StripeAddressElement {
 
     const disabled = this.progress === 'loading';
 
+    // NOTE: `stripe-payment-sheet-wrap` below is a legacy CSS class kept for backward
+    // compatibility (leftover from a former component name). It is part of the public
+    // DOM contract — consumers may target it in their own stylesheets — so it must
+    // remain in the rendered output. Do not remove it.
     return (
       <div class="stripe-payment-sheet-wrap">
         <form id="stripe-address-element-form">

--- a/src/components/stripe-express-checkout-element/stripe-express-checkout-element.tsx
+++ b/src/components/stripe-express-checkout-element/stripe-express-checkout-element.tsx
@@ -240,7 +240,7 @@ export class StripeExpressCheckoutElement {
       stripe: this.stripeService.getStripe(),
     };
 
-    if (this.stripeDidLoaded) {
+    if (this.stripeDidLoaded != null) {
       this.stripeDidLoaded(event);
     }
 
@@ -315,7 +315,7 @@ export class StripeExpressCheckoutElement {
     this.stripeService = serviceFactory.createStripeService();
     this.expressCheckoutManager = serviceFactory.createExpressCheckoutElementManager(this.stripeService);
 
-    if (this.publishableKey) {
+    if (this.publishableKey != null && this.publishableKey !== '') {
       this.initStripe(this.publishableKey, {
         stripeAccount: this.stripeAccount,
       });
@@ -323,7 +323,7 @@ export class StripeExpressCheckoutElement {
   }
 
   componentWillUpdate() {
-    if (!this.stripeService.state.publishableKey) {
+    if (this.stripeService.state.publishableKey == null || this.stripeService.state.publishableKey === '') {
       return;
     }
 
@@ -347,11 +347,11 @@ export class StripeExpressCheckoutElement {
       const stripe = this.stripeService.getStripe();
       const { intentType, clientSecret } = this;
 
-      if (!stripe) {
+      if (stripe == null) {
         throw new Error('Stripe not initialized');
       }
 
-      if (!clientSecret) {
+      if (clientSecret == null || clientSecret === '') {
         throw new Error('Client secret is required');
       }
 
@@ -377,7 +377,7 @@ export class StripeExpressCheckoutElement {
         });
       })();
 
-      if (result.error) {
+      if (result.error != null) {
         throw new StripeAPIError(result.error);
       }
 
@@ -410,11 +410,11 @@ export class StripeExpressCheckoutElement {
       elementOptions.amount = this.amount;
     }
 
-    if (this.currency) {
+    if (this.currency != null && this.currency !== '') {
       elementOptions.currency = this.currency;
     }
 
-    if (this.buttonHeight) {
+    if (this.buttonHeight != null && this.buttonHeight !== '') {
       // Convert string like "48px" to number for Stripe API
       if (typeof this.buttonHeight === 'string') {
         const height = parseInt(this.buttonHeight.replace('px', ''), 10);
@@ -432,7 +432,7 @@ export class StripeExpressCheckoutElement {
       onConfirm: async event => {
         this.confirm.emit(event);
 
-        if (this.shouldUseDefaultConfirmAction && this.clientSecret) {
+        if (this.shouldUseDefaultConfirmAction && this.clientSecret != null && this.clientSecret !== '') {
           await this.defaultConfirmAction(event);
         }
       },

--- a/src/services/address-element-manager.ts
+++ b/src/services/address-element-manager.ts
@@ -37,12 +37,12 @@ export class AddressElementManager implements IAddressElementManager {
   async initialize(containerElement: HTMLElement, options?: import('@stripe/stripe-js').StripeAddressElementOptions): Promise<StripeAddressElement> {
     const elements = this.stripeService.getElements();
 
-    if (!elements) {
+    if (elements == null) {
       throw new Error('StripeService not initialized. Call StripeService.initialize() first.');
     }
 
     // Unmount if already initialized
-    if (this.addressElement) {
+    if (this.addressElement != null) {
       this.unmount();
     }
 
@@ -89,7 +89,7 @@ export class AddressElementManager implements IAddressElementManager {
    * Unmount address element
    */
   unmount(): void {
-    if (!this.addressElement) {
+    if (this.addressElement == null) {
       return;
     }
 

--- a/src/services/card-element-manager.ts
+++ b/src/services/card-element-manager.ts
@@ -36,12 +36,12 @@ export class CardElementManager implements ICardElementManager {
   async initialize(containerElement: HTMLElement): Promise<CardElementInstances> {
     const elements = this.stripeService.getElements();
 
-    if (!elements) {
+    if (elements == null) {
       throw new Error('StripeService not initialized. Call StripeService.initialize() first.');
     }
 
     // Unmount if already initialized
-    if (this.cardElements) {
+    if (this.cardElements != null) {
       this.unmount();
     }
 
@@ -103,7 +103,7 @@ export class CardElementManager implements ICardElementManager {
    * Unmount all card elements
    */
   unmount(): void {
-    if (!this.cardElements) {
+    if (this.cardElements == null) {
       return;
     }
 

--- a/src/services/currency-selector-element-manager.ts
+++ b/src/services/currency-selector-element-manager.ts
@@ -38,12 +38,12 @@ export class CurrencySelectorElementManager implements ICurrencySelectorElementM
   async initialize(containerElement: HTMLElement, options?: any): Promise<StripeCurrencySelectorElement> {
     const elements = this.stripeService.getElements();
 
-    if (!elements) {
+    if (elements == null) {
       throw new Error('StripeService not initialized. Call StripeService.initialize() first.');
     }
 
     // Unmount if already initialized
-    if (this.currencySelectorElement) {
+    if (this.currencySelectorElement != null) {
       this.unmount();
     }
 
@@ -98,7 +98,7 @@ export class CurrencySelectorElementManager implements ICurrencySelectorElementM
    * Unmount currency selector element
    */
   unmount(): void {
-    if (!this.currencySelectorElement) {
+    if (this.currencySelectorElement == null) {
       return;
     }
 

--- a/src/services/express-checkout-element-manager.ts
+++ b/src/services/express-checkout-element-manager.ts
@@ -42,12 +42,12 @@ export class ExpressCheckoutElementManager implements IExpressCheckoutElementMan
   ): Promise<StripeExpressCheckoutElement> {
     const elements = this.stripeService.getElements();
 
-    if (!elements) {
+    if (elements == null) {
       throw new Error('StripeService not initialized. Call StripeService.initialize() first.');
     }
 
     // Unmount if already initialized
-    if (this.expressCheckoutElement) {
+    if (this.expressCheckoutElement != null) {
       this.unmount();
     }
 
@@ -71,23 +71,23 @@ export class ExpressCheckoutElementManager implements IExpressCheckoutElementMan
     const mountPoint = await findElement(containerElement, '#express-checkout-element');
 
     // Set up event handlers before mounting
-    if (eventHandlers?.onConfirm) {
+    if (eventHandlers?.onConfirm != null) {
       expressCheckout.on('confirm', eventHandlers.onConfirm);
     }
 
-    if (eventHandlers?.onClick) {
+    if (eventHandlers?.onClick != null) {
       expressCheckout.on('click', eventHandlers.onClick);
     }
 
-    if (eventHandlers?.onCancel) {
+    if (eventHandlers?.onCancel != null) {
       expressCheckout.on('cancel', eventHandlers.onCancel);
     }
 
-    if (eventHandlers?.onShippingAddressChange) {
+    if (eventHandlers?.onShippingAddressChange != null) {
       expressCheckout.on('shippingaddresschange', eventHandlers.onShippingAddressChange);
     }
 
-    if (eventHandlers?.onShippingRateChange) {
+    if (eventHandlers?.onShippingRateChange != null) {
       expressCheckout.on('shippingratechange', eventHandlers.onShippingRateChange);
     }
 
@@ -116,7 +116,7 @@ export class ExpressCheckoutElementManager implements IExpressCheckoutElementMan
    * @param options - Partial options to update
    */
   update(options: Partial<ExpressCheckoutElementOptions>): void {
-    if (!this.expressCheckoutElement) {
+    if (this.expressCheckoutElement == null) {
       console.warn('Express Checkout Element not initialized. Cannot update options.');
       return;
     }
@@ -154,7 +154,7 @@ export class ExpressCheckoutElementManager implements IExpressCheckoutElementMan
    * Unmount express checkout element
    */
   unmount(): void {
-    if (!this.expressCheckoutElement) {
+    if (this.expressCheckoutElement == null) {
       return;
     }
 

--- a/src/services/link-authentication-element-manager.ts
+++ b/src/services/link-authentication-element-manager.ts
@@ -47,12 +47,12 @@ export class LinkAuthenticationElementManager implements ILinkAuthenticationElem
   async initialize(containerElement: HTMLElement, options?: StripeLinkAuthenticationElementOptions): Promise<StripeLinkAuthenticationElement> {
     const elements = this.stripeService.getElements();
 
-    if (!elements) {
+    if (elements == null) {
       throw new Error('StripeService not initialized. Call StripeService.initialize() first.');
     }
 
     // Unmount if already initialized
-    if (this.linkAuthenticationElement) {
+    if (this.linkAuthenticationElement != null) {
       this.unmount();
     }
 
@@ -99,7 +99,7 @@ export class LinkAuthenticationElementManager implements ILinkAuthenticationElem
    * Unmount link authentication element
    */
   unmount(): void {
-    if (!this.linkAuthenticationElement) {
+    if (this.linkAuthenticationElement == null) {
       return;
     }
 

--- a/src/services/payment-element-manager.ts
+++ b/src/services/payment-element-manager.ts
@@ -39,7 +39,7 @@ export class PaymentElementManager implements IPaymentElementManager {
     const isCheckoutSession = this.stripeService.state.isCheckoutSession;
 
     // Unmount if already initialized
-    if (this.paymentElement) {
+    if (this.paymentElement != null) {
       this.unmount();
     }
 
@@ -47,7 +47,7 @@ export class PaymentElementManager implements IPaymentElementManager {
       // Checkout Session mode: use checkout.createPaymentElement()
       const checkout = this.stripeService.getCheckout();
 
-      if (!checkout) {
+      if (checkout == null) {
         throw new Error('StripeService not initialized with Checkout Session. Call StripeService.initializeWithCheckoutSession() first.');
       }
 
@@ -57,7 +57,7 @@ export class PaymentElementManager implements IPaymentElementManager {
       // Payment Intent mode: use elements.create('payment')
       const elements = this.stripeService.getElements();
 
-      if (!elements) {
+      if (elements == null) {
         throw new Error('StripeService not initialized. Call StripeService.initialize() first.');
       }
 
@@ -104,7 +104,7 @@ export class PaymentElementManager implements IPaymentElementManager {
    * Unmount payment element
    */
   unmount(): void {
-    if (!this.paymentElement) {
+    if (this.paymentElement == null) {
       return;
     }
 

--- a/src/services/stripe-service.ts
+++ b/src/services/stripe-service.ts
@@ -53,11 +53,11 @@ class StripeServiceClass implements IStripeService {
     // Update configuration
     this.store.state.publishableKey = publishableKey;
     this.store.state.isCheckoutSession = false;
-    if (options?.stripeAccount != null && options.stripeAccount !== '') {
+    if (options?.stripeAccount != null && options?.stripeAccount !== '') {
       this.store.state.stripeAccount = options.stripeAccount;
     }
 
-    if (options?.applicationName != null && options.applicationName !== '') {
+    if (options?.applicationName != null && options?.applicationName !== '') {
       this.store.state.applicationName = options.applicationName;
     }
 
@@ -102,11 +102,11 @@ class StripeServiceClass implements IStripeService {
     // Update configuration
     this.store.state.publishableKey = publishableKey;
     this.store.state.isCheckoutSession = true;
-    if (options?.stripeAccount != null && options.stripeAccount !== '') {
+    if (options?.stripeAccount != null && options?.stripeAccount !== '') {
       this.store.state.stripeAccount = options.stripeAccount;
     }
 
-    if (options?.applicationName != null && options.applicationName !== '') {
+    if (options?.applicationName != null && options?.applicationName !== '') {
       this.store.state.applicationName = options.applicationName;
     }
 

--- a/src/services/stripe-service.ts
+++ b/src/services/stripe-service.ts
@@ -53,11 +53,11 @@ class StripeServiceClass implements IStripeService {
     // Update configuration
     this.store.state.publishableKey = publishableKey;
     this.store.state.isCheckoutSession = false;
-    if (options?.stripeAccount) {
+    if (options?.stripeAccount != null && options.stripeAccount !== '') {
       this.store.state.stripeAccount = options.stripeAccount;
     }
 
-    if (options?.applicationName) {
+    if (options?.applicationName != null && options.applicationName !== '') {
       this.store.state.applicationName = options.applicationName;
     }
 
@@ -102,11 +102,11 @@ class StripeServiceClass implements IStripeService {
     // Update configuration
     this.store.state.publishableKey = publishableKey;
     this.store.state.isCheckoutSession = true;
-    if (options?.stripeAccount) {
+    if (options?.stripeAccount != null && options.stripeAccount !== '') {
       this.store.state.stripeAccount = options.stripeAccount;
     }
 
-    if (options?.applicationName) {
+    if (options?.applicationName != null && options.applicationName !== '') {
       this.store.state.applicationName = options.applicationName;
     }
 

--- a/src/utils/element-finder.spec.ts
+++ b/src/utils/element-finder.spec.ts
@@ -47,7 +47,7 @@ describe('element-finder', () => {
     });
 
     afterEach(() => {
-      if (containerElement.parentNode) {
+      if (containerElement.parentNode != null) {
         document.body.removeChild(containerElement);
       }
       jest.clearAllTimers();

--- a/src/utils/element-finder.ts
+++ b/src/utils/element-finder.ts
@@ -9,7 +9,7 @@ export function findElement(containerElement: HTMLElement, selector: string, tim
   return new Promise((resolve, reject) => {
     const elem = containerElement.querySelector(selector);
 
-    if (elem) {
+    if (elem != null) {
       return resolve(elem as HTMLElement);
     }
 
@@ -21,7 +21,7 @@ export function findElement(containerElement: HTMLElement, selector: string, tim
     const observer = new MutationObserver(() => {
       const elem = containerElement.querySelector(selector);
 
-      if (elem) {
+      if (elem != null) {
         clearTimeout(timeoutId);
         observer.disconnect();
         resolve(elem as HTMLElement);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -14,12 +14,12 @@ export const checkPlatform = () => {
 
 export const waitForElm = (el: HTMLStripeCardElementElement, selector: string): Promise<HTMLElement> => {
   return new Promise(resolve => {
-    if (el.querySelector(selector)) {
+    if (el.querySelector(selector) != null) {
       return resolve(el.querySelector(selector) as HTMLElement);
     }
 
     const observer = new MutationObserver(() => {
-      if (el.querySelector(selector)) {
+      if (el.querySelector(selector) != null) {
         resolve(el.querySelector(selector) as HTMLElement);
         observer.disconnect();
       }


### PR DESCRIPTION
## Summary

Repo-wide, behavior-preserving lint cleanup for the remaining components plus the `services/` and `utils/` layers.

- **Explicit boolean conditions** (`strict-boolean-conditions`): converted implicit string/nullable truthiness checks to explicit `!= null` / `== null` / `!== ''` comparisons, preserving exact runtime semantics (including the "skip when undefined or empty" behavior for optional config strings). Touches:
  - `src/services/`: `stripe-service.ts`, `payment-element-manager.ts`, `link-authentication-element-manager.ts`, `address-element-manager.ts`, `card-element-manager.ts`, `currency-selector-element-manager.ts`, `express-checkout-element-manager.ts`
  - `src/utils/`: `utils.ts`, `element-finder.ts` (+ spec)
  - `src/components/stripe-express-checkout-element/`, `src/components/stripe-address-element/`
- **Legacy class documented**: `stripe-payment-sheet-wrap` on `stripe-address-element` kept as-is (public DOM contract) and annotated as a backward-compatibility legacy class.

Remaining lint warnings left intentionally reflect public `@Prop` API choices (`ban-default-true`, `strict-mutable`, `decorators-style`) and are out of scope.

## Backward compatibility

No public API or rendered DOM changes. Snapshots untouched. Verified with the full unit suite (407 tests pass) and a production build.

## Scope

1 of 4 independent cleanup PRs. Covers all components/services/utils except `stripe-payment-element` and `stripe-card-element`, which have their own PRs.

https://claude.ai/code/session_01MvsmLGxaFQq8XcGN7mcWo2

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvsmLGxaFQq8XcGN7mcWo2)_