### PR TITLE
docs: add SECURITY.md, SAQ-A explanation, and funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [hideokamoto]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Use one of the following channels instead:
+
+1. **GitHub Security Advisories (preferred)** — open a private advisory at
+   `https://github.com/wpkyoto/stripe-pwa-elements/security/advisories/new`.
+2. **Direct email** — contact the lead maintainer Hidetaka Okamoto at the email
+   address listed on his GitHub profile (<https://github.com/hideokamoto>).
+
+### Response SLA
+
+| Step | Target time |
+|---|---|
+| Initial acknowledgement | Within **2 business days** |
+| Triage / impact assessment | Within **5 business days** |
+| Fix or mitigation published | Within **30 days** for critical/high; best-effort for lower severity |
+
+We will coordinate a responsible-disclosure timeline with you before publishing any advisory.
+
+---
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| 3.x (latest) | Yes |
+| 2.x | Security fixes only (best-effort) |
+| < 2.x | No |
+
+---
+
+## Scope
+
+This package wraps Stripe's official JavaScript SDK (`@stripe/stripe-js`) and Stripe Elements.
+Card data **never** passes through this library's DOM, JavaScript memory, or network requests —
+all sensitive fields are rendered inside Stripe-hosted iframes (see the SAQ-A note in
+[`readme.md`](./readme.md#security--pci-dss-saq-a)).
+
+Vulnerabilities in `@stripe/stripe-js` itself should be reported directly to Stripe at
+<https://stripe.com/docs/security/stripe>.
+
+---
+
+## Supply Chain
+
+### npm provenance
+
+We recommend publishing releases with attestation so consumers can verify that a package
+on npm was built from this exact source tree:
+
+```bash
+# Requires npm ≥ 9.5 and a GitHub Actions environment with id-token permission
+npm publish --provenance
+```
+
+When the CI publish workflow is added in the future, include this flag.
+Maintainers publishing locally should also pass `--provenance` if their npm version
+supports it and they are authenticated to a supported registry.
+
+For reference, the recommended `publishConfig` entry in `package.json` to opt in
+automatically is:
+
+```json
+{
+  "publishConfig": {
+    "provenance": true
+  }
+}
+```
+
+This entry is **not yet present** in `package.json` because releases currently use `np`
+locally rather than a CI publish workflow. It will be added once the CI workflow is in place.
+
+---
+
+## Acknowledgements
+
+We follow the [Contributor Covenant Code of Conduct](.github/CODE_OF_CONDUCT.md).

--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,55 @@ To run the unit tests for the components, run:
 npm test
 ```
 
+## Security & PCI DSS SAQ-A
+
+Card data **never** passes through this library's DOM, JavaScript state, or network requests.
+All sensitive input fields (card number, expiry, CVC) are rendered inside **Stripe-hosted iframes**,
+meaning your page never has access to raw card data. This architecture keeps integrations
+eligible for the lightest PCI DSS self-assessment questionnaire: **SAQ-A**.
+
+### How iframe isolation works
+
+```
+Your page (your domain)
+┌─────────────────────────────────────────────────────────┐
+│  <stripe-card-element>                                  │
+│  ┌───────────────────────────────────────────────────┐  │
+│  │  <iframe src="https://js.stripe.com/...">         │  │
+│  │  ┌─────────────────────────────────────────────┐  │  │
+│  │  │  Card number  [____ ____ ____ ____]          │  │  │
+│  │  │  Expiry       [MM/YY]  CVC  [___]            │  │  │
+│  │  │                                              │  │  │
+│  │  │  (Stripe's origin — cross-origin boundary)   │  │  │
+│  │  └─────────────────────────────────────────────┘  │  │
+│  └───────────────────────────────────────────────────┘  │
+│                                                         │
+│  Your JS can call stripe.confirmPayment() but           │
+│  CANNOT read card values from the iframe.               │
+└─────────────────────────────────────────────────────────┘
+```
+
+- The browser's **same-origin policy** prevents any JavaScript on your page from reading
+  input values inside Stripe's iframe.
+- Card data travels directly from the iframe to **Stripe's servers over TLS** — it never
+  touches your application server.
+- This library only manages the mounting, styling, and event wiring of those iframes; it
+  does not alter Stripe's security model.
+
+For a complete explanation see [Stripe's SAQ-A documentation](https://stripe.com/docs/security/stripe#saq-a).
+
+For the vulnerability reporting channel and supply-chain notes (npm provenance), see [SECURITY.md](./SECURITY.md).
+
+---
+
+## Sponsors
+
+If stripe-pwa-elements saves you time, please consider sponsoring the lead maintainer:
+
+[![Sponsor hideokamoto](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa?logo=github-sponsors&style=flat-square)](https://github.com/sponsors/hideokamoto)
+
+---
+
 ## Maintainers
 
 | Maintainer | GitHub | Social |


### PR DESCRIPTION
## Summary

- **SECURITY.md** (new): vulnerability reporting channel (GitHub Security Advisories + maintainer Hidetaka Okamoto direct contact), supported versions table, response SLA (2 business days acknowledgement / 30 days fix for critical), scope note explaining Stripe iframe isolation, and a `## Supply chain` subsection documenting `npm publish --provenance` and the future `publishConfig` entry.
- **readme.md** — `## Security & PCI DSS SAQ-A` section (new): explains that card data never passes through this library's DOM or JS state because Stripe Elements render inside cross-origin iframes; includes an ASCII diagram showing the iframe boundary.
- **readme.md** — `## Sponsors` section (new): adds a shields.io GitHub Sponsors badge linking to `github.com/sponsors/hideokamoto`.
- **.github/FUNDING.yml** (new): `github: [hideokamoto]` — enables the GitHub Sponsors button on the repository page.

## What changed

| File | Change |
|---|---|
| `SECURITY.md` | New file — vulnerability policy, SLA, supported versions, scope, supply-chain notes |
| `readme.md` | Two new sections appended before `## Maintainers`: Security/SAQ-A and Sponsors |
| `.github/FUNDING.yml` | New file — GitHub Sponsors config |

No TypeScript/source changes were made. ESLint and build were not run (only documentation files changed).

## Manual follow-up required

- **Activate GitHub Sponsors account**: visit https://github.com/sponsors and complete onboarding for the `hideokamoto` account. The `.github/FUNDING.yml` is in place; the button will appear automatically once the account is active.
- **Add `--provenance` to the publish process**: once a CI-based publish workflow is added (currently releases use `np` locally), include `npm publish --provenance` (or `"provenance": true` in `publishConfig`) to generate signed build attestations on npm.

https://claude.ai/code/session_019mgmkx7G5ZmM8uA9uT8Xry