### PR TITLE
feat: re-export public types from package root

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -246,6 +246,37 @@ If stripe-pwa-elements saves you time, please consider sponsoring the lead maint
 
 ---
 
+## Public API & TypeScript types
+
+All user-facing TypeScript types are exported directly from the package root. Import them using the package name:
+
+```ts
+import type {
+  FormSubmitEvent,
+  FormSubmitHandler,
+  StripeLoadedEvent,
+  StripeDidLoadedHandler,
+  ProgressStatus,
+  IntentType,
+  InitStripeOptions,
+  LinkAuthenticationElementChangeEvent,
+  LinkAuthenticationElementChangeHandler,
+  CurrencySelectorChangeEvent,
+  CurrencySelectorChangeHandler,
+  DefaultFormSubmitResult,
+} from 'stripe-pwa-elements';
+```
+
+**Do not** import from internal paths such as `dist/types/interfaces` or `dist-custom-elements/...`. Those paths are implementation details and are not part of the public API — they may change without notice across any release.
+
+### Semver policy
+
+All types exported from the package root (`stripe-pwa-elements`) are considered **public API** and follow [Semantic Versioning](https://semver.org/). Within the `^3.0.0` range:
+
+- No breaking changes will be made to the shape of any publicly exported type.
+- New optional fields may be added to event objects without a major bump.
+- Removals or renames of exported types always require a new major version.
+
 ## Maintainers
 
 | Maintainer | GitHub | Social |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,16 @@
 export { Components, JSX } from './components';
+export type {
+  FormSubmitEvent,
+  FormSubmitHandler,
+  StripeLoadedEvent,
+  StripeDidLoadedHandler,
+  ProgressStatus,
+  IntentType,
+  InitStripeOptions,
+  LinkAuthenticationElementChangeEvent,
+  LinkAuthenticationElementChangeHandler,
+  CurrencySelectorChangeEvent,
+  CurrencySelectorChangeHandler,
+  DefaultFormSubmitResult,
+} from './interfaces';
 import 'ionicons';


### PR DESCRIPTION
## Summary

- Re-exports all user-facing TypeScript types from `src/index.ts` so consumers can import them from the package root instead of internal `dist/types/...` paths.
- Adds a `## Public API & TypeScript types` section to `readme.md` documenting the supported import pattern and the semver policy for exported types.
- `StringifyBoolean` is intentionally excluded — it is an internal utility type not meant for consumers.

## What changed

**`src/index.ts`** — added `export type { ... } from './interfaces'` for:
`FormSubmitEvent`, `FormSubmitHandler`, `StripeLoadedEvent`, `StripeDidLoadedHandler`, `ProgressStatus`, `IntentType`, `InitStripeOptions`, `LinkAuthenticationElementChangeEvent`, `LinkAuthenticationElementChangeHandler`, `CurrencySelectorChangeEvent`, `CurrencySelectorChangeHandler`, `DefaultFormSubmitResult`.

**`readme.md`** — new `## Public API & TypeScript types` section (inserted before Maintainers/License) that:
- Shows `import type { FormSubmitEvent } from 'stripe-pwa-elements'` as the supported pattern.
- Explicitly warns against importing from `dist/types/interfaces` or other internal paths.
- States the semver policy: all root-exported types follow semver; no breaking changes within `^3.0.0`.

## Background

`@capacitor-community/stripe`'s `web.ts` currently imports types via internal paths like `dist/types/interfaces`. Those paths are implementation details — they can silently break whenever the build output layout changes. By re-exporting from the package root we give external consumers a stable, semver-protected surface.

## Test plan

- [x] `pnpm exec tsc --noEmit` — passes with no errors
- [x] `pnpm run lint` — passes with 0 errors (pre-existing warnings only, unrelated to this change)
- [ ] `@capacitor-community/stripe` should update its `web.ts` to import from `stripe-pwa-elements` directly (external repo — see Manual follow-up below)

## Manual follow-up

The `@capacitor-community/stripe` package imports types from internal paths (e.g. `dist/types/interfaces`). Once this PR is merged and a new version is published, that repo should be updated to use:

```ts
import type { FormSubmitEvent } from 'stripe-pwa-elements';
```

https://claude.ai/code/session_019mgmkx7G5ZmM8uA9uT8Xry