### PR TITLE
chore: improve npm/readme discoverability metadata and cross-links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stripe-pwa-elements",
   "version": "3.2.0",
-  "description": "Framework-agnostic Stripe payment web components for any web app or PWA",
+  "description": "Framework-agnostic Stripe Payment Elements as Web Components",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "es2015": "dist/esm/index.mjs",
@@ -47,16 +47,20 @@
   },
   "keywords": [
     "stripe",
+    "stripe-elements",
+    "payment-element",
+    "web-components",
     "web-component",
-    "payment",
-    "pwa",
+    "framework-agnostic",
+    "capacitor",
+    "stenciljs",
     "stencil",
+    "pwa",
+    "payment",
     "apple-pay",
     "google-pay",
-    "card-element",
-    "payment-element",
     "checkout",
-    "web-components"
+    "card-element"
   ],
   "homepage": "https://github.com/wpkyoto/stripe-pwa-elements#readme",
   "bugs": {

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,17 @@
 
 Framework-agnostic Stripe payment components built with Web Components. Works with any web framework — React, Vue, Angular, Svelte, or plain HTML.
 
+> **Note:** The current npm package is **`stripe-pwa-elements`** (this repo).
+> The old package `@stripe-elements/stripe-elements` (v2.0.2) is deprecated and superseded — please use `stripe-pwa-elements` instead.
+
+## Used in production
+
+[![capacitor-community/stripe](https://img.shields.io/badge/capacitor--community%2Fstripe-4000%2B%20weekly%20downloads-brightgreen)](https://github.com/capacitor-community/stripe)
+
+This library powers the Web implementation of [`@capacitor-community/stripe`](https://github.com/capacitor-community/stripe), which receives 4,000+ weekly downloads. If you use Capacitor for cross-platform apps, `stripe-pwa-elements` handles all Stripe UI on the web layer.
+
+> **Manual follow-up (external repo):** Add a reciprocal link in the [capacitor-community/stripe README](https://github.com/capacitor-community/stripe) pointing back to this package.
+
 ## Features
 
 - **Framework-agnostic** — Standard Web Components that work everywhere


### PR DESCRIPTION
## Summary

- **package.json metadata:** Updated `description` to the exact canonical string `"Framework-agnostic Stripe Payment Elements as Web Components"` and merged keywords to include all required terms (`stripe-elements`, `framework-agnostic`, `capacitor`, `stenciljs`) with no duplicates. Existing useful keywords (`web-component`, `stencil`, `payment`) are preserved.
- **Old package notice:** Added a blockquote callout near the top of `readme.md` (just below the title) stating that `stripe-pwa-elements` is the current package and that the old `@stripe-elements/stripe-elements` (v2.0.2) is deprecated/superseded.
- **Capacitor cross-link:** Added a "Used in production" section with a badge and short prose linking to [`capacitor-community/stripe`](https://github.com/capacitor-community/stripe), noting 4,000+ weekly downloads via Capacitor. Both additions are near the top of the README to minimise conflict with other teams appending to the bottom.

## What changed

| File | Change |
|------|--------|
| `package.json` | `description` updated; `keywords` array expanded with 4 new terms, no removals |
| `readme.md` | Deprecation notice blockquote added; "Used in production" section added — both just below the title, above Features |

## Manual follow-up (out of scope for this PR)

1. Run `npm deprecate @stripe-elements/stripe-elements "This package is deprecated. Please use stripe-pwa-elements instead."` (requires npm publish credentials for the old package scope).
2. Set GitHub repository topics on `hideokamoto/stripe-pwa-elements` to match the updated keywords (e.g. `stripe`, `web-components`, `capacitor`, `stenciljs`, `pwa`).
3. Add a reciprocal link in the [capacitor-community/stripe README](https://github.com/capacitor-community/stripe) pointing back to `stripe-pwa-elements`.

https://claude.ai/code/session_019mgmkx7G5ZmM8uA9uT8Xry