### PR TITLE
docs: add Claude Code skill/plugin for stripe-pwa-elements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "stripe-pwa-elements",
+  "owner": {
+    "name": "stripe-pwa-elements maintainers",
+    "url": "https://github.com/hideokamoto/stripe-pwa-elements"
+  },
+  "description": "Claude Code skills for the stripe-pwa-elements web component library",
+  "plugins": [
+    {
+      "name": "stripe-pwa-elements",
+      "source": "./plugins/stripe-pwa-elements",
+      "description": "Integrate Stripe PWA web components (card, payment, express checkout, address, link auth, etc.) correctly",
+      "keywords": ["stripe", "payments", "web-components", "stencil", "pwa"],
+      "license": "MIT"
+    }
+  ]
+}

--- a/plugins/stripe-pwa-elements/.claude-plugin/plugin.json
+++ b/plugins/stripe-pwa-elements/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "stripe-pwa-elements",
+  "description": "Helps you integrate the stripe-pwa-elements web component library: choosing the right component, wiring publishable key + intent/checkout client secret, and handling the submit/confirm flow.",
+  "author": {
+    "name": "Hidetaka Okamoto",
+    "url": "https://github.com/hideokamoto"
+  },
+  "homepage": "https://github.com/hideokamoto/stripe-pwa-elements",
+  "repository": "https://github.com/hideokamoto/stripe-pwa-elements",
+  "license": "MIT",
+  "keywords": ["stripe", "payments", "web-components", "stencil", "pwa"]
+}

--- a/plugins/stripe-pwa-elements/skills/stripe-pwa-elements/SKILL.md
+++ b/plugins/stripe-pwa-elements/skills/stripe-pwa-elements/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: stripe-pwa-elements
+description: >-
+  Use when integrating Stripe payments into a web app with the
+  `stripe-pwa-elements` library — i.e. when the user mentions stripe-pwa-elements
+  or uses its custom element tags (<stripe-card-element>, <stripe-payment-element>,
+  <stripe-express-checkout-element>, <stripe-address-element>,
+  <stripe-link-authentication-element>, <stripe-currency-selector>, <stripe-modal>,
+  <stripe-card-element-modal>, <stripe-payment-request-button>). Covers install,
+  choosing the right component, wiring the publishable key + intent/checkout client
+  secret, lazy-load timing, and the submit/confirm flow. Works for plain HTML/JS,
+  React, Vue, Angular, and Svelte.
+license: MIT
+---
+
+# Integrating stripe-pwa-elements
+
+`stripe-pwa-elements` is a framework-agnostic Web Component library (built with
+Stencil) that wraps Stripe Elements. It works in plain HTML, React, Vue, Angular,
+and Svelte. This skill helps you pick the right component and wire it up correctly.
+
+## Install
+
+```bash
+npm install stripe-pwa-elements
+```
+
+Register the custom elements once at app startup (bundler/ESM):
+
+```js
+import { defineCustomElements } from 'stripe-pwa-elements/loader';
+defineCustomElements();
+```
+
+Or load directly from a CDN (no build step):
+
+```html
+<script type="module" src="https://unpkg.com/stripe-pwa-elements/dist/wpkyoto/stripe-pwa-elements.esm.js"></script>
+```
+
+## Choose the right component
+
+| You want to…                                                        | Use this tag                          |
+| ------------------------------------------------------------------- | ------------------------------------- |
+| One unified form for cards, wallets & local methods (**recommended**) | `<stripe-payment-element>`            |
+| One-click Apple Pay / Google Pay / Link / PayPal                    | `<stripe-express-checkout-element>`   |
+| Classic split card fields (number / expiry / CVC)                   | `<stripe-card-element>`               |
+| Card fields presented inside a built-in modal                       | `<stripe-card-element-modal>`         |
+| Collect a billing/shipping address                                  | `<stripe-address-element>`            |
+| Collect email + offer Stripe Link                                   | `<stripe-link-authentication-element>`|
+| Let the buyer choose a currency (Adaptive Pricing)                  | `<stripe-currency-selector>`          |
+| A reusable modal wrapper around any of the above                    | `<stripe-modal>`                      |
+| Low-level Payment Request button (Beta)                             | `<stripe-payment-request-button>`     |
+
+When unsure, prefer `<stripe-payment-element>` — it adapts to the buyer's location
+and the payment methods enabled in the Stripe Dashboard.
+
+## Golden-path rules (always follow these)
+
+1. **Secrets come from the server.** Create the PaymentIntent / SetupIntent /
+   Checkout Session on your backend with your **secret** key, and pass only the
+   *publishable* key (`pk_test_…` / `pk_live_…`) and the resulting *client secret*
+   to the browser. Never put a secret key (`sk_…` / `rk_…`) in client code.
+
+2. **Set the publishable key plus the correct secret prop** for the component:
+   - `<stripe-payment-element>`, `<stripe-card-element>`, `<stripe-card-element-modal>` → `intent-client-secret` (`pi_…_secret_…` or `seti_…_secret_…`)
+   - `<stripe-payment-element>` in Checkout Session mode → `checkout-session-client-secret` (or the `initStripeWithCheckoutSession()` method)
+   - `<stripe-express-checkout-element>` → `client-secret`
+   - `<stripe-currency-selector>` → `client-secret` (Checkout Session)
+   - `<stripe-address-element>` / `<stripe-link-authentication-element>` → publishable key only
+
+3. **Wait for the element before scripting it.** Components lazy-load Stripe.js, so
+   guard with `await customElements.whenDefined('<tag>')` and/or listen for the
+   `stripeLoaded` event before calling any method.
+
+4. **Attributes are kebab-case; events are camelCase `CustomEvent`s.** A prop like
+   `intentClientSecret` is the HTML attribute `intent-client-secret`. Read event
+   payloads from `event.detail`. In React use `onFormSubmit`; in Vue use
+   `@formSubmit`.
+
+5. **Default vs. manual submit.** By default the form components confirm the payment
+   for you and emit the result on `defaultFormSubmitResult` (or `defaultConfirmResult`
+   for express checkout). To run your own logic instead, set
+   `should-use-default-form-submit-action="false"` (express checkout:
+   `should-use-default-confirm-action="false"`) and handle the `formSubmit` /
+   `confirm` event yourself.
+
+6. **Use test mode while developing** (`pk_test_…`). Generate a client secret fast
+   with the Stripe CLI, e.g.
+   `stripe payment_intents create --amount=1099 --currency=usd | jq -r .client_secret`.
+
+## Shared API (most components)
+
+- `initStripe(publishableKey, { stripeAccount? })` — load Stripe.js & mount.
+- `updateProgress('' | 'loading' | 'success' | 'failure')` — drive the button state.
+- `setErrorMessage(message)` — show an inline error.
+- `stripeLoaded` event — fires with `{ stripe }` once Stripe.js is ready.
+
+`applicationName` and `stripe-account` (Connect) props are available on every
+Stripe-backed component. i18n (English, Japanese, Portuguese) is auto-detected from
+the browser.
+
+## Going deeper
+
+- **Full props / events / methods for every component:** see [reference.md](reference.md).
+- **Copy-paste, end-to-end recipes** (PaymentIntent, Checkout Session, Express
+  Checkout, Address, Link, modal): see [examples.md](examples.md).
+
+Always cross-check exact prop and event names against [reference.md](reference.md)
+before generating code — do not guess attribute names.

--- a/plugins/stripe-pwa-elements/skills/stripe-pwa-elements/examples.md
+++ b/plugins/stripe-pwa-elements/skills/stripe-pwa-elements/examples.md
@@ -1,0 +1,199 @@
+# stripe-pwa-elements — Integration recipes
+
+Copy-paste starting points. All use a publishable key (`pk_test_…`) and a client
+secret created on your **server**. Replace the placeholder values. See
+[reference.md](reference.md) for exact prop/event names.
+
+> Loading: either `import { defineCustomElements } from 'stripe-pwa-elements/loader'; defineCustomElements();`
+> in a bundled app, or add the unpkg `<script type="module">` tag (see SKILL.md) for plain HTML.
+
+---
+
+## 1. Payment Element — default submit (let the library confirm)
+
+Simplest path. The component calls `stripe.confirmPayment()` and emits the result.
+
+```html
+<stripe-payment-element
+  publishable-key="pk_test_xxxxx"
+  intent-client-secret="pi_xxxxx_secret_xxxxx"
+></stripe-payment-element>
+
+<script>
+  customElements.whenDefined('stripe-payment-element').then(() => {
+    const el = document.querySelector('stripe-payment-element');
+    el.addEventListener('defaultFormSubmitResult', ({ detail }) => {
+      if (detail instanceof Error || detail.error) {
+        el.updateProgress('failure');
+        console.error('Payment failed', detail);
+      } else {
+        el.updateProgress('success');
+        console.log('Payment succeeded', detail);
+        // redirect to your success page, close modal, etc.
+      }
+    });
+  });
+</script>
+```
+
+To save a card instead of charging, set `intent-type="setup"` and pass a SetupIntent
+client secret (`seti_…_secret_…`).
+
+## 2. Payment Element — manual submit (your own confirm logic)
+
+Set `should-use-default-form-submit-action="false"` and handle `formSubmit`.
+
+```html
+<stripe-payment-element
+  publishable-key="pk_test_xxxxx"
+  intent-client-secret="pi_xxxxx_secret_xxxxx"
+  should-use-default-form-submit-action="false"
+></stripe-payment-element>
+
+<script>
+  customElements.whenDefined('stripe-payment-element').then(() => {
+    const el = document.querySelector('stripe-payment-element');
+    el.addEventListener('formSubmit', async ({ detail: { stripe, elements } }) => {
+      const result = await stripe.confirmPayment({
+        elements,
+        confirmParams: { return_url: 'https://example.com/order/complete' },
+        redirect: 'if_required',
+      });
+      if (result.error) {
+        el.setErrorMessage(result.error.message);
+        el.updateProgress('failure');
+      } else {
+        el.updateProgress('success');
+      }
+    });
+  });
+</script>
+```
+
+## 3. Payment Element — Checkout Session mode
+
+Use a Checkout Session client secret (`cs_…_secret_…`) via the dedicated method.
+
+```js
+const el = document.querySelector('stripe-payment-element');
+await customElements.whenDefined('stripe-payment-element');
+await el.initStripeWithCheckoutSession('pk_test_xxxxx', 'cs_xxxxx_secret_xxxxx');
+
+el.addEventListener('checkoutSessionConfirmResult', ({ detail }) => {
+  if (detail instanceof Error || detail.type === 'error') {
+    el.updateProgress('failure');
+  } else {
+    el.updateProgress('success'); // detail.session has the result
+  }
+});
+```
+
+You can also set the `checkout-session-client-secret` attribute declaratively
+instead of calling the method.
+
+## 4. Express Checkout (Apple Pay / Google Pay / Link)
+
+```js
+const el = document.createElement('stripe-express-checkout-element');
+el.setAttribute('publishable-key', 'pk_test_xxxxx');
+el.setAttribute('client-secret', 'pi_xxxxx_secret_xxxxx');
+el.setAttribute('amount', '1099');      // minor units
+el.setAttribute('currency', 'usd');
+el.setAttribute('button-height', '48px');
+document.getElementById('container').appendChild(el);
+
+await customElements.whenDefined('stripe-express-checkout-element');
+
+el.addEventListener('defaultConfirmResult', ({ detail }) => {
+  console.log(detail instanceof Error ? 'failed' : 'succeeded', detail);
+});
+
+await el.initStripe('pk_test_xxxxx');
+```
+
+Buttons only appear when the browser/device supports the wallet. For custom
+handling set `should-use-default-confirm-action="false"` and handle `confirm`.
+
+## 5. Card Element inside a modal (manual flow)
+
+```html
+<stripe-modal open="true">
+  <stripe-card-element
+    publishable-key="pk_test_xxxxx"
+    intent-client-secret="pi_xxxxx_secret_xxxxx"
+    should-use-default-form-submit-action="false"
+  ></stripe-card-element>
+</stripe-modal>
+
+<script>
+  customElements.whenDefined('stripe-card-element').then(() => {
+    const el = document.querySelector('stripe-card-element');
+    el.addEventListener('formSubmit', async ({ detail }) => {
+      const { stripe, cardNumberElement } = detail;
+      const result = await stripe.createPaymentMethod({
+        type: 'card',
+        card: cardNumberElement, // also: cardExpiryElement, cardCVCElement
+      });
+      // Send result.paymentMethod.id to your server to confirm the PaymentIntent.
+      el.updateProgress(result.error ? 'failure' : 'success');
+    });
+  });
+</script>
+```
+
+## 6. Address Element
+
+```js
+const el = document.querySelector('stripe-address-element'); // mode="shipping" / "billing"
+await customElements.whenDefined('stripe-address-element');
+el.addEventListener('formSubmit', ({ detail: { address } }) => {
+  console.log(address.value, address.complete);
+  el.updateProgress('success');
+});
+// Or read on demand:
+const { value, complete } = await el.getValue();
+```
+
+## 7. Link Authentication Element
+
+```js
+const el = document.querySelector('stripe-link-authentication-element');
+await customElements.whenDefined('stripe-link-authentication-element');
+el.addEventListener('linkAuthenticationChange', ({ detail: { email } }) => {
+  console.log('email', email);
+});
+const email = await el.getEmail();
+```
+
+---
+
+## Framework notes
+
+- **React**: register once with `defineCustomElements()`; bind events with the
+  camelCase `on` prop, e.g. `onFormSubmit={handler}`. Set array/object props
+  (like `allowedCountries`) via a `ref` since they aren't attributes.
+- **Vue**: use `@formSubmit="handler"`; make sure custom elements are allowed in
+  your compiler options.
+- **Angular**: add `CUSTOM_ELEMENTS_SCHEMA`; bind with `(formSubmit)="handler($event)"`.
+- **Plain HTML**: load the unpkg script tag and use `customElements.whenDefined`.
+
+## Server side (create the secret)
+
+Never expose your secret key in the browser. Create the intent server-side:
+
+```js
+// Node.js
+const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+const intent = await stripe.paymentIntents.create({
+  amount: 1099,
+  currency: 'usd',
+  automatic_payment_methods: { enabled: true },
+});
+// send intent.client_secret to the browser
+```
+
+For quick local testing, generate one with the Stripe CLI:
+
+```bash
+stripe payment_intents create --amount=1099 --currency=usd | jq -r .client_secret
+```

--- a/plugins/stripe-pwa-elements/skills/stripe-pwa-elements/examples.md
+++ b/plugins/stripe-pwa-elements/skills/stripe-pwa-elements/examples.md
@@ -1,7 +1,8 @@
 # stripe-pwa-elements — Integration recipes
 
-Copy-paste starting points. All use a publishable key (`pk_test_…`) and a client
-secret created on your **server**. Replace the placeholder values. See
+Copy-paste starting points. Most use a publishable key (`pk_test_…`) and a client
+secret created on your **server** — a few (Address and Link Authentication) need
+only a publishable key. Replace the placeholder values. See
 [reference.md](reference.md) for exact prop/event names.
 
 > Loading: either `import { defineCustomElements } from 'stripe-pwa-elements/loader'; defineCustomElements();`
@@ -80,7 +81,11 @@ await customElements.whenDefined('stripe-payment-element');
 await el.initStripeWithCheckoutSession('pk_test_xxxxx', 'cs_xxxxx_secret_xxxxx');
 
 el.addEventListener('checkoutSessionConfirmResult', ({ detail }) => {
-  if (detail instanceof Error || detail.type === 'error') {
+  if (detail instanceof Error) {
+    el.setErrorMessage(detail.message);
+    el.updateProgress('failure');
+  } else if (detail.type === 'error') {
+    el.setErrorMessage(detail.error.message);
     el.updateProgress('failure');
   } else {
     el.updateProgress('success'); // detail.session has the result
@@ -105,7 +110,12 @@ document.getElementById('container').appendChild(el);
 await customElements.whenDefined('stripe-express-checkout-element');
 
 el.addEventListener('defaultConfirmResult', ({ detail }) => {
-  console.log(detail instanceof Error ? 'failed' : 'succeeded', detail);
+  if (detail instanceof Error || detail.error) {
+    el.setErrorMessage(detail.error ? detail.error.message : detail.message);
+    el.updateProgress('failure');
+  } else {
+    el.updateProgress('success');
+  }
 });
 
 await el.initStripe('pk_test_xxxxx');
@@ -134,8 +144,13 @@ handling set `should-use-default-confirm-action="false"` and handle `confirm`.
         type: 'card',
         card: cardNumberElement, // also: cardExpiryElement, cardCVCElement
       });
-      // Send result.paymentMethod.id to your server to confirm the PaymentIntent.
-      el.updateProgress(result.error ? 'failure' : 'success');
+      if (result.error) {
+        el.setErrorMessage(result.error.message);
+        el.updateProgress('failure');
+      } else {
+        // Send result.paymentMethod.id to your server to confirm the PaymentIntent.
+        el.updateProgress('success');
+      }
     });
   });
 </script>
@@ -182,14 +197,17 @@ const email = await el.getEmail();
 Never expose your secret key in the browser. Create the intent server-side:
 
 ```js
-// Node.js
+// Node.js — wrap in an async function (top-level await isn't valid in CommonJS)
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
-const intent = await stripe.paymentIntents.create({
-  amount: 1099,
-  currency: 'usd',
-  automatic_payment_methods: { enabled: true },
-});
-// send intent.client_secret to the browser
+
+async function createIntent() {
+  const intent = await stripe.paymentIntents.create({
+    amount: 1099,
+    currency: 'usd',
+    automatic_payment_methods: { enabled: true },
+  });
+  return intent.client_secret; // send this to the browser
+}
 ```
 
 For quick local testing, generate one with the Stripe CLI:

--- a/plugins/stripe-pwa-elements/skills/stripe-pwa-elements/reference.md
+++ b/plugins/stripe-pwa-elements/skills/stripe-pwa-elements/reference.md
@@ -1,0 +1,249 @@
+# stripe-pwa-elements — Component API reference
+
+Authoritative props, events, and public methods for every component. Attributes are
+the kebab-case form of the prop name (e.g. prop `intentClientSecret` →
+attribute `intent-client-secret`). Events are `CustomEvent`s; read data from
+`event.detail`. All public methods are `async` (return Promises).
+
+Common props on every Stripe-backed component:
+
+- `publishable-key` (`string`) — your Stripe publishable key.
+- `stripe-account` (`string`, optional) — Connect account id for API calls.
+- `application-name` (`string`, default `'stripe-pwa-elements'`) — wrapper app id.
+
+Common methods: `initStripe(publishableKey, { stripeAccount? })`,
+`setErrorMessage(message)`. Common event: `stripeLoaded` → `{ stripe }`.
+
+`ProgressStatus` = `'' | 'loading' | 'success' | 'failure'`.
+`intent-type` = `'payment'` (default) | `'setup'`.
+
+---
+
+## `<stripe-card-element>`
+
+Split card fields (number / expiry / CVC). Supports PaymentIntent and SetupIntent.
+
+**Props**
+
+| Attribute | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `publishable-key` | `string` | — | required |
+| `intent-client-secret` | `string` | — | `pi_…_secret_…` or `seti_…_secret_…` |
+| `intent-type` | `'payment' \| 'setup'` | `'payment'` | |
+| `zip` | `boolean` | `true` | show ZIP field |
+| `sheet-title` | `string` | `'Add your payment information'` | translated |
+| `button-label` | `string` | `'Pay'` | translated |
+| `show-label` | `boolean` | `false` | show field labels |
+| `show-payment-request-button` | `boolean` | — | render the Payment Request button |
+| `should-use-default-form-submit-action` | `boolean` | `true` | when `true`, calls `stripe.confirmCardPayment` for you |
+| `stripe-account` | `string` | — | |
+| `application-name` | `string` | `'stripe-pwa-elements'` | |
+
+**Events**
+
+- `stripeLoaded` → `{ stripe }`
+- `formSubmit` → `{ stripe, cardNumberElement, cardExpiryElement, cardCVCElement, intentClientSecret?, zipCode? }`
+- `defaultFormSubmitResult` → `PaymentIntentResult | SetupIntentResult | Error`
+
+**Methods**: `initStripe`, `setErrorMessage`, `updateProgress(progress)`,
+`setPaymentRequestOption(option)`.
+
+---
+
+## `<stripe-payment-element>`
+
+Unified payment form (cards, wallets, local methods). Two modes: Payment/Setup
+Intent **or** Checkout Session.
+
+**Props**
+
+| Attribute | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `publishable-key` | `string` | — | required |
+| `intent-client-secret` | `string` | — | Payment/Setup Intent mode |
+| `checkout-session-client-secret` | `string` | — | Checkout Session mode (or use the method below) |
+| `intent-type` | `'payment' \| 'setup'` | `'payment'` | |
+| `sheet-title` | `string` | `'Add your payment information'` | translated |
+| `button-label` | `string` | `'Pay'` | translated |
+| `should-use-default-form-submit-action` | `boolean` | `true` | when `true`, calls `stripe.confirmPayment` for you |
+| `stripe-account` | `string` | — | |
+| `application-name` | `string` | `'stripe-pwa-elements'` | |
+
+**Events**
+
+- `stripeLoaded` → `{ stripe }`
+- `formSubmit` → `{ stripe, elements?, intentClientSecret?, checkout?, checkoutSessionClientSecret? }`
+- `defaultFormSubmitResult` → `PaymentIntentResult | SetupIntentResult | Error` (Intent mode)
+- `checkoutSessionConfirmResult` → `{ type: 'success'; session } | { type: 'error'; error } | Error` (Checkout Session mode)
+
+**Methods**: `initStripe`, `initStripeWithCheckoutSession(publishableKey, checkoutSessionClientSecret, options?)`,
+`setErrorMessage`, `updateProgress(progress)`.
+
+---
+
+## `<stripe-express-checkout-element>`
+
+One-click wallets: Apple Pay, Google Pay, Link, PayPal, Amazon Pay.
+
+**Props**
+
+| Attribute | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `publishable-key` | `string` | — | required |
+| `client-secret` | `string` | — | Payment/Setup Intent client secret |
+| `intent-type` | `'payment' \| 'setup'` | `'payment'` | |
+| `amount` | `number` | — | minor units, e.g. `1099` = $10.99 |
+| `currency` | `string` | — | ISO code, e.g. `'usd'` |
+| `button-height` | `string` | — | e.g. `'48px'` |
+| `should-use-default-confirm-action` | `boolean` | `true` | when `true`, confirms the payment for you |
+| `stripe-account` | `string` | — | |
+| `application-name` | `string` | `'stripe-pwa-elements'` | |
+
+**Events**
+
+- `stripeLoaded` → `{ stripe }`
+- `expressCheckoutClick` — buyer clicked a wallet button
+- `confirm` — buyer authorized the payment
+- `cancel` — buyer dismissed the sheet
+- `defaultConfirmResult` → `PaymentIntentResult | SetupIntentResult | Error`
+
+**Methods**: `initStripe`, `setErrorMessage`, `updateProgress(progress)`,
+`updateElementOptions(options)` — dynamically update `mode`, `amount`, `currency`,
+`paymentMethods`, `buttonType`, `buttonTheme`, `buttonHeight`, `layout`.
+
+---
+
+## `<stripe-address-element>`
+
+Billing or shipping address collection.
+
+**Props**
+
+| Attribute | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `publishable-key` | `string` | — | required |
+| `mode` | `'billing' \| 'shipping'` | `'billing'` | |
+| `default-country` | `string` | — | e.g. `'US'`, `'JP'` |
+| `allowed-countries` (prop `allowedCountries`) | `string[]` | — | set via property, not attribute |
+| `sheet-title` | `string` | `'Billing address'` | translated |
+| `button-label` | `string` | `'Save'` | translated |
+| `show-label` | `boolean` | `false` | |
+| `stripe-account` | `string` | — | |
+| `application-name` | `string` | `'stripe-pwa-elements'` | |
+
+**Events**
+
+- `stripeLoaded` → `{ stripe }`
+- `formSubmit` → `{ address: { value: { name, firstName?, lastName?, address: { line1, line2, city, state, postal_code, country }, phone? }, complete } }`
+
+**Methods**: `initStripe`, `setErrorMessage`, `updateProgress(progress)`,
+`getValue()` → `{ value, complete }`.
+
+---
+
+## `<stripe-link-authentication-element>`
+
+Email field with Stripe Link.
+
+**Props**
+
+| Attribute | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `publishable-key` | `string` | — | required |
+| `default-email` | `string` | — | prefill |
+| `stripe-account` | `string` | — | |
+| `application-name` | `string` | `'stripe-pwa-elements'` | |
+
+**Events**
+
+- `stripeLoaded` → `{ stripe }`
+- `linkAuthenticationChange` → `{ stripe, linkAuthenticationElement, email? }`
+
+**Methods**: `initStripe`, `setErrorMessage`, `updateProgress(progress)`,
+`getEmail()` → `string | undefined`.
+
+---
+
+## `<stripe-currency-selector>`
+
+Currency picker for Stripe Adaptive Pricing (Checkout Session).
+
+**Props**
+
+| Attribute | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `publishable-key` | `string` | — | required |
+| `client-secret` | `string` | — | Checkout Session client secret (required) |
+| `stripe-account` | `string` | — | |
+| `application-name` | `string` | `'stripe-pwa-elements'` | |
+
+**Events**
+
+- `stripeLoaded` → `{ stripe }`
+- `currencyChange` → `{ currency }`
+
+**Methods**: `initStripe`, `setErrorMessage`, `getSelectedCurrency()` → `string | undefined`.
+
+---
+
+## `<stripe-modal>`
+
+Reusable modal wrapper (the only component using shadow DOM). Put any payment
+component inside it as a child.
+
+**Props**
+
+| Attribute | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `open` | `boolean` | `false` | open state |
+| `show-close-button` | `boolean` | `true` | |
+
+**Events**: `close`.
+
+**Methods**: `openModal()`, `closeModal()`, `toggleModal()`.
+
+---
+
+## `<stripe-card-element-modal>`
+
+Card Element pre-wrapped in a modal.
+
+**Props**: all of `<stripe-card-element>`'s payment props
+(`publishable-key`, `intent-client-secret`, `intent-type`, `zip`, `sheet-title`,
+`button-label`, `show-label`, `should-use-default-form-submit-action`,
+`stripe-account`, `application-name`) **plus** the modal props `open` and
+`show-close-button`.
+
+**Events**: `closed`.
+
+**Methods**: `present()` (opens the modal; resolves on form submission),
+`getStripeCardElementElement()` → inner `<stripe-card-element>`,
+`updateProgress(progress)`, `setPaymentRequestButton(options)`, `destroy()`.
+
+---
+
+## `<stripe-payment-request-button>` (Beta)
+
+Low-level Payment Request API button (Apple Pay / Google Pay). Prefer
+`<stripe-express-checkout-element>` for most use cases.
+
+**Props**
+
+| Attribute / prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `publishable-key` | `string` | — | required |
+| `paymentMethodEventHandler` | `(event, stripe) => Promise<void>` | — | property only |
+| `shippingAddressEventHandler` | `(event, stripe) => Promise<void>` | — | property only |
+| `shippingOptionEventHandler` | `(event, stripe) => Promise<void>` | — | property only |
+| `stripe-account` | `string` | — | |
+| `application-name` | `string` | `'stripe-pwa-elements'` | |
+
+**Events**: `stripeLoaded` → `{ stripe }`.
+
+**Methods**:
+- `initStripe(publishableKey, { showButton?, stripeAccount? })`
+- `isAvailable('applePay' | 'googlePay')` — call **before** `initStripe`
+- `setPaymentRequestOption(option)` — `PaymentRequestOptions` (country, currency, total, etc.)
+- `setPaymentMethodEventHandler(handler)`
+- `setPaymentRequestShippingAddressEventHandler(handler)`
+- `setPaymentRequestShippingOptionEventHandler(handler)`

--- a/plugins/stripe-pwa-elements/skills/stripe-pwa-elements/reference.md
+++ b/plugins/stripe-pwa-elements/skills/stripe-pwa-elements/reference.md
@@ -35,7 +35,7 @@ Split card fields (number / expiry / CVC). Supports PaymentIntent and SetupInten
 | `button-label` | `string` | `'Pay'` | translated |
 | `show-label` | `boolean` | `false` | show field labels |
 | `show-payment-request-button` | `boolean` | — | render the Payment Request button |
-| `should-use-default-form-submit-action` | `boolean` | `true` | when `true`, calls `stripe.confirmCardPayment` for you |
+| `should-use-default-form-submit-action` | `boolean` | `true` | when `true`, confirms for you: `stripe.confirmCardPayment` for `intent-type="payment"`, `stripe.confirmCardSetup` for `intent-type="setup"` |
 | `stripe-account` | `string` | — | |
 | `application-name` | `string` | `'stripe-pwa-elements'` | |
 
@@ -65,7 +65,7 @@ Intent **or** Checkout Session.
 | `intent-type` | `'payment' \| 'setup'` | `'payment'` | |
 | `sheet-title` | `string` | `'Add your payment information'` | translated |
 | `button-label` | `string` | `'Pay'` | translated |
-| `should-use-default-form-submit-action` | `boolean` | `true` | when `true`, calls `stripe.confirmPayment` for you |
+| `should-use-default-form-submit-action` | `boolean` | `true` | when `true`, confirms for you: `stripe.confirmPayment` for `intent-type="payment"`, `stripe.confirmSetup` for `intent-type="setup"` |
 | `stripe-account` | `string` | — | |
 | `application-name` | `string` | `'stripe-pwa-elements'` | |
 

--- a/readme.md
+++ b/readme.md
@@ -283,6 +283,22 @@ See the [example/](./example) directory for complete working examples:
 - [Address Element](./example/address-example.html) — Address collection
 - [Express Checkout](./example/example-express-checkout.html) — Apple Pay, Google Pay, etc.
 
+## Use with Claude Code
+
+This repo ships a [Claude Code](https://claude.com/claude-code) skill that teaches
+the assistant how to integrate `stripe-pwa-elements` correctly — picking the right
+component, wiring the publishable key + client secret, and handling the
+submit/confirm flow. Install it as a plugin:
+
+```text
+/plugin marketplace add hideokamoto/stripe-pwa-elements
+/plugin install stripe-pwa-elements@stripe-pwa-elements
+```
+
+Once installed, the skill activates automatically when Claude detects you are
+working with the library, or you can invoke it explicitly with
+`/stripe-pwa-elements:stripe-pwa-elements`.
+
 ## Contribution
 
 ### Getting Started


### PR DESCRIPTION
Ship a Claude Code Agent Skill so users of the library can install it
and have Claude generate correct integration code.

- .claude-plugin/marketplace.json: marketplace manifest at repo root
- plugins/stripe-pwa-elements: plugin with a single skill
  - SKILL.md: component chooser + golden-path rules (auto-invoked)
  - reference.md: full per-component props/events/methods
  - examples.md: copy-paste integration recipes
- readme.md: add "Use with Claude Code" install section

Install via:
  /plugin marketplace add hideokamoto/stripe-pwa-elements
  /plugin install stripe-pwa-elements@stripe-pwa-elements