### PR TITLE
ci: scope security audit to the published library (docs advisories non-blocking)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,12 @@ jobs:
           name: ESLint
           command: pnpm run lint
       - run:
-          name: Security audit (moderate+, prod deps only)
-          command: pnpm audit --audit-level=moderate --prod
+          name: Security audit (library prod deps; docs-only advisories are non-blocking)
+          # `pnpm audit` cannot be scoped to a single workspace member, so this
+          # wrapper blocks only on advisories that reach the published library
+          # and demotes docs-site tooling advisories to warnings.
+          # See scripts/ci-audit.mjs.
+          command: node scripts/ci-audit.mjs
 
   type-check:
     executor: default

--- a/scripts/ci-audit.mjs
+++ b/scripts/ci-audit.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * CI security-audit gate, scoped to the published library.
+ *
+ * Background
+ * ----------
+ * `pnpm audit` always scans the whole pnpm workspace, and this repo's workspace
+ * includes the `docs` site (Astro/Starlight) as a member. An advisory in the
+ * docs site's build tooling (e.g. astro > esbuild) therefore turns the library
+ * CI red even though those packages are never published to npm (the library
+ * only ships `dist/` and `loader/`). `pnpm audit` has no per-package filter, so
+ * we post-process its JSON output here instead.
+ *
+ * Behaviour
+ * ---------
+ * - Runs `pnpm audit --json --prod`.
+ * - Considers advisories at `moderate` severity or above.
+ * - An advisory BLOCKS CI (exit 1) if any of its dependency paths reaches the
+ *   published library (i.e. a path that is not solely inside the `docs`
+ *   workspace).
+ * - An advisory that comes ONLY from the `docs` workspace is reported as a
+ *   non-blocking warning so the maintainer still sees it, but it does not stop
+ *   unrelated work.
+ *
+ * This keeps the supply-chain gate on everything that actually ships, while
+ * letting docs-tooling advisories be handled on their own schedule.
+ */
+import { execSync } from 'node:child_process';
+
+const BLOCKING_SEVERITIES = new Set(['moderate', 'high', 'critical']);
+// Workspace members whose advisories must not block the library CI.
+const NON_BLOCKING_WORKSPACE_PREFIXES = ['docs>'];
+const NON_BLOCKING_WORKSPACE_EXACT = new Set(['docs']);
+
+function isDocsOnlyPath(path) {
+  return NON_BLOCKING_WORKSPACE_EXACT.has(path) || NON_BLOCKING_WORKSPACE_PREFIXES.some(prefix => path.startsWith(prefix));
+}
+
+let raw = '';
+try {
+  raw = execSync('pnpm audit --json --prod', { encoding: 'utf8' });
+} catch (error) {
+  // `pnpm audit` exits non-zero when advisories exist; the JSON report is still
+  // written to stdout, so recover it from the thrown error.
+  raw = error.stdout ? error.stdout.toString() : '';
+  if (!raw.trim()) {
+    console.error('ci-audit: `pnpm audit` produced no output.');
+    if (error.stderr) {
+      console.error(error.stderr.toString());
+    }
+    process.exit(1);
+  }
+}
+
+let report;
+try {
+  report = JSON.parse(raw);
+} catch (error) {
+  console.error('ci-audit: failed to parse `pnpm audit --json` output:', error.message);
+  process.exit(1);
+}
+
+const advisories = report.advisories || {};
+const blocking = [];
+const ignored = [];
+
+for (const id of Object.keys(advisories)) {
+  const advisory = advisories[id];
+  if (!BLOCKING_SEVERITIES.has(advisory.severity)) {
+    continue;
+  }
+
+  const paths = (advisory.findings || []).flatMap(finding => finding.paths || []);
+  const reachesLibrary = paths.some(path => !isDocsOnlyPath(path));
+  const label = `${advisory.severity.toUpperCase()}  ${advisory.module_name}  ${advisory.url || `advisory ${id}`}`;
+
+  if (reachesLibrary) {
+    blocking.push(`${label}\n      paths: ${paths.join(', ')}`);
+  } else {
+    ignored.push(label);
+  }
+}
+
+if (ignored.length > 0) {
+  console.log('Non-blocking advisories (docs workspace tooling only — not published to npm):');
+  for (const entry of ignored) {
+    console.log(`  - ${entry}`);
+  }
+  console.log('');
+}
+
+if (blocking.length > 0) {
+  console.error('Blocking advisories affecting the published library:');
+  for (const entry of blocking) {
+    console.error(`  - ${entry}`);
+  }
+  console.error(`\nci-audit: ${blocking.length} moderate+ advisory(ies) affect shipped code. Failing CI.`);
+  process.exit(1);
+}
+
+console.log(`ci-audit: no moderate+ advisories affect the published library (${ignored.length} docs-only advisory(ies) ignored). OK.`);
+process.exit(0);


### PR DESCRIPTION
## Why

`pnpm audit` (run by the CircleCI `lint` job) always scans the **entire pnpm workspace**, and this repo's workspace includes the `docs` site (`pnpm-workspace.yaml` → `docs`). So an advisory in the docs site's build tooling turns the **library** CI red — even on a docs-only or unrelated PR — despite those packages never being published to npm (the library ships only `dist/` and `loader/`).

That is exactly what happened: `docs > astro > esbuild` (GHSA-gv7w-rqvm-qjhr) failed the audit step on every open PR and on `main`.

`pnpm audit` has **no per-workspace-member filter** — `pnpm --filter=… audit` errors with `Unknown option: 'recursive'` — so scoping has to be done by post-processing the audit report.

## What this changes

- **`scripts/ci-audit.mjs`** (new): runs `pnpm audit --json --prod`, then:
  - **Blocks CI** (exit 1) on any `moderate`+ advisory whose dependency path reaches the published library.
  - **Demotes to a non-blocking warning** any advisory that comes *solely* from the `docs` workspace, so the maintainer still sees it but unrelated work isn't stopped.
- **`.circleci/config.yml`**: the `lint` job now runs `node scripts/ci-audit.mjs` instead of the raw `pnpm audit --audit-level=moderate --prod`.

## Verification (on `main`, where the esbuild advisory is still present)

```
$ pnpm audit --audit-level=moderate --prod   # old command
exit 1   ❌

$ node scripts/ci-audit.mjs                   # new gate
Non-blocking advisories (docs workspace tooling only — not published to npm):
  - HIGH  esbuild  https://github.com/advisories/GHSA-gv7w-rqvm-qjhr
ci-audit: no moderate+ advisories affect the published library (1 docs-only advisory(ies) ignored). OK.
exit 0   ✅
```

## Trade-off / relationship to the esbuild fix

- The supply-chain gate is **fully preserved for everything that ships** — a vulnerable library dependency still fails CI exactly as before.
- This does **not** silence the esbuild advisory itself; that is fixed separately by pinning `esbuild` in the other PR. This PR is the structural prevention so a future docs-tooling advisory can't block library work again.
- Severity threshold remains `moderate`+ (now enforced in the script rather than via `--audit-level`).

https://claude.ai/code/session_019mgmkx7G5ZmM8uA9uT8Xry

---
_Generated by [Claude Code](https://claude.ai/code/session_019mgmkx7G5ZmM8uA9uT8Xry)_