### PR TITLE
feat(docs): add configurable Cloudflare Web Analytics to documentation site

### DIFF
--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -1,0 +1,64 @@
+# Docs Site Analytics
+
+This document explains how to enable web analytics on the documentation site and lists the remaining operational measurement tasks that are not automated by this repository.
+
+## In-repo instrumentation: Cloudflare Web Analytics
+
+The docs site (`docs/`) uses **Cloudflare Web Analytics** for privacy-friendly, cookie-free traffic measurement. The beacon script is injected at build time via the Starlight `head` configuration in `docs/astro.config.mjs`.
+
+The beacon is **only included in the built output when the `PUBLIC_CF_ANALYTICS_TOKEN` environment variable is set**. If the variable is absent the site builds normally with no analytics code emitted — so local development and CI builds remain clean without any configuration.
+
+### Enabling analytics
+
+1. Create a Cloudflare Web Analytics site in the Cloudflare dashboard (<https://dash.cloudflare.com/>) and copy the token shown in the beacon snippet.
+2. Set the environment variable before building or in your deployment environment:
+
+   ```bash
+   # Local build with analytics enabled
+   PUBLIC_CF_ANALYTICS_TOKEN=your_token_here pnpm run build
+   ```
+
+   For Cloudflare Workers / Wrangler deployments, add the variable as a secret or in `wrangler.jsonc` under `[vars]` (do **not** commit a real token):
+
+   ```jsonc
+   // wrangler.jsonc — use wrangler secret put PUBLIC_CF_ANALYTICS_TOKEN for production
+   {
+     "name": "stripe-pwa-elements-docs",
+     "compatibility_date": "2025-01-01",
+     "assets": { "directory": "./dist" }
+   }
+   ```
+
+   Recommended: store the token as a Wrangler secret so it never appears in source control:
+
+   ```bash
+   wrangler secret put PUBLIC_CF_ANALYTICS_TOKEN
+   ```
+
+3. Deploy as usual (`pnpm run deploy`). Cloudflare Web Analytics will appear in the dashboard within a few minutes of the first page views.
+
+### What is tracked
+
+Cloudflare Web Analytics collects page views, referrers, browsers, and countries without setting cookies or storing personal data. It is compliant with GDPR and CCPA without requiring a consent banner.
+
+---
+
+## Operational measurement tasks (not automated by this repository)
+
+The following KPI measurements are manual or operational. They do not require any code changes and are not managed by this repository.
+
+### npm download tracking
+
+- **npm-stat** (<https://npm-stat.com/charts.html?package=stripe-pwa-elements>): provides download history charts for the package. Bookmark and check periodically.
+- **pkgstats** (<https://pkgstats.dev/pkg/stripe-pwa-elements>): alternative dashboard for npm download trends.
+- Both services read from the public npm registry — no setup required, no credentials needed.
+
+### GitHub repository Insights
+
+The GitHub repository provides built-in traffic and engagement metrics under the **Insights** tab (only visible to repository collaborators):
+
+- **Traffic → Views**: unique visitors and total page views over the last 14 days.
+- **Traffic → Clones**: how often the repository is cloned.
+- **Stars / Forks**: tracked automatically; historical trends visible on third-party tools such as [Star History](https://star-history.com/#wpkyoto/stripe-pwa-elements).
+
+These metrics are not exportable via a public API without authentication; recording them over time requires a manual snapshot process or a scheduled script using the GitHub API with a personal access token.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -5,7 +5,7 @@ import mermaid from 'astro-mermaid';
 
 // Cloudflare Web Analytics beacon is injected only when PUBLIC_CF_ANALYTICS_TOKEN is set.
 // Set this environment variable at build/deploy time — never hard-code a real token.
-const cfAnalyticsToken = process.env.PUBLIC_CF_ANALYTICS_TOKEN;
+const cfAnalyticsToken = process.env.PUBLIC_CF_ANALYTICS_TOKEN?.trim();
 const analyticsHeadEntries = cfAnalyticsToken
 	? [
 			{

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,6 +3,22 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import mermaid from 'astro-mermaid';
 
+// Cloudflare Web Analytics beacon is injected only when PUBLIC_CF_ANALYTICS_TOKEN is set.
+// Set this environment variable at build/deploy time — never hard-code a real token.
+const cfAnalyticsToken = process.env.PUBLIC_CF_ANALYTICS_TOKEN;
+const analyticsHeadEntries = cfAnalyticsToken
+	? [
+			{
+				tag: 'script',
+				attrs: {
+					defer: true,
+					src: 'https://static.cloudflareinsights.com/beacon.min.js',
+					'data-cf-beacon': JSON.stringify({ token: cfAnalyticsToken }),
+				},
+			},
+		]
+	: [];
+
 // https://astro.build/config
 export default defineConfig({
 	integrations: [
@@ -17,6 +33,7 @@ export default defineConfig({
 				en: { label: 'English' },
 			},
 			social: [{ icon: 'github', label: 'GitHub', href: 'https://github.com/wpkyoto/stripe-pwa-elements' }],
+			head: analyticsHeadEntries,
 			sidebar: [
 				{
 					label: 'Getting Started',


### PR DESCRIPTION
## Summary

- Injects the Cloudflare Web Analytics beacon script into every page of the Astro/Starlight docs site via the Starlight `head` config in `docs/astro.config.mjs`.
- The snippet is **gated on the `PUBLIC_CF_ANALYTICS_TOKEN` environment variable**: if the variable is absent the site builds cleanly with no analytics code emitted, so local development and CI builds require no configuration.
- Adds `docs/ANALYTICS.md` documenting how to set the env var to enable tracking, and listing the remaining operational measurement tasks that are out-of-scope for this repository.

## What this PR does NOT cover (operational follow-ups)

The following KPI measurement tasks are manual/operational and do not require code changes in this repository:

- **npm download tracking** — check [npm-stat](https://npm-stat.com/charts.html?package=stripe-pwa-elements) and [pkgstats](https://pkgstats.dev/pkg/stripe-pwa-elements) periodically; no setup required.
- **GitHub Insights** — Stars, Forks, and Traffic (Views/Clones) are available under the repository's Insights tab. Recording historical data requires a manual snapshot process or a scheduled script using the GitHub API.

## How to enable analytics

1. Create a site in [Cloudflare Web Analytics](https://dash.cloudflare.com/) and copy the beacon token.
2. Set the env var at build/deploy time:
   ```bash
   PUBLIC_CF_ANALYTICS_TOKEN=your_token_here pnpm run build
   ```
   Or store it as a Wrangler secret for production:
   ```bash
   wrangler secret put PUBLIC_CF_ANALYTICS_TOKEN
   ```

## Test plan

- [x] Docs build succeeds **without** `PUBLIC_CF_ANALYTICS_TOKEN` set — no beacon script in output
- [x] Docs build succeeds **with** `PUBLIC_CF_ANALYTICS_TOKEN=test-token-12345` — beacon script present in every HTML page
- [x] No real token committed anywhere in the repository

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEgdiGG98TPsGZVeUj6St4)_