### PR TITLE
docs: accept rk_test_ restricted keys in addition to sk_test_

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -120,7 +120,7 @@ entries are no longer trusted unless you include them). Each entry may be an exa
 2. Edit `.dev.vars` and fill in your test key:
 
    ```bash
-   STRIPE_SECRET_KEY=sk_test_your_key_here
+   STRIPE_SECRET_KEY=sk_test_or_rk_test_your_key_here
    ALLOWED_ORIGINS=http://localhost:4321
    ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ npm run docs:build
 The docs site exposes two API endpoints that allow demo HTML (e.g. StackBlitz embeds) to obtain a Stripe
 `clientSecret` using only a public `pk_test_` key in the browser. The secret key stays on the server.
 
-> **WARNING**: Only Stripe test keys (`sk_test_*`) are permitted. Never configure a `sk_live_` key.
+> **WARNING**: Only Stripe test keys (`sk_test_*` or `rk_test_*`) are permitted. Never configure a live key (`sk_live_*` / `rk_live_*`).
 > The server validates the key prefix and will refuse to start if a live key is found.
 
 ### Endpoints

--- a/docs/README.md
+++ b/docs/README.md
@@ -141,7 +141,7 @@ Set the secret via Wrangler — never commit it to the repository:
 
 ```bash
 wrangler secret put STRIPE_SECRET_KEY
-# When prompted, paste your sk_test_ key
+# When prompted, paste your sk_test_ or rk_test_ key
 ```
 
 Then deploy:
@@ -150,5 +150,12 @@ Then deploy:
 pnpm run deploy
 ```
 
-> **Reminder**: Only `sk_test_` keys are accepted. Providing a `sk_live_` key will cause the endpoint
-> to return a 500 error without leaking any secret or stack trace.
+> **Reminder**: Only test-mode keys (`sk_test_` or `rk_test_`) are accepted. Providing a live key
+> (`sk_live_` / `rk_live_`) will cause the endpoint to return a 500 error without leaking any
+> secret or stack trace.
+>
+> **Recommended**: Use a **restricted key** (`rk_test_`) with only these permissions:
+> - `PaymentIntents: Write`
+> - `Checkout Sessions: Write`
+>
+> This minimises blast radius if the key is ever exposed.

--- a/docs/src/lib/api-helpers.ts
+++ b/docs/src/lib/api-helpers.ts
@@ -100,6 +100,7 @@ let cachedStripe: Stripe | null = null;
  * which is required for Cloudflare Workers compatibility.
  * The instance is cached per isolate to avoid re-initializing it on every request.
  * Throws an error (without leaking the key) if the key is missing or is a live key.
+ * Accepts both full test secret keys (`sk_test_`) and restricted test keys (`rk_test_`).
  */
 export function getStripe(env: ApiEnv): Stripe {
   if (cachedStripe) {
@@ -109,8 +110,8 @@ export function getStripe(env: ApiEnv): Stripe {
   if (!key) {
     throw new Error('STRIPE_SECRET_KEY is not configured.');
   }
-  if (!key.startsWith('sk_test_')) {
-    throw new Error('Only Stripe test keys (sk_test_) are allowed.');
+  if (!key.startsWith('sk_test_') && !key.startsWith('rk_test_')) {
+    throw new Error('Only Stripe test keys (sk_test_ or rk_test_) are allowed.');
   }
   cachedStripe = new Stripe(key, {
     httpClient: Stripe.createFetchHttpClient(),


### PR DESCRIPTION
Allow Stripe restricted test keys (rk_test_) as a more secure alternative to full secret keys. Update README to recommend using a restricted key with only PaymentIntents:Write and Checkout Sessions:Write permissions.