### PR TITLE
Update repository ownership from wpkyoto to hideokamoto

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/wpkyoto/stripe-pwa-elements.esm.js",
+  "unpkg": "dist/stripe-elements/stripe-elements.esm.js",
   "files": [
     "dist/",
     "loader/"

--- a/package.json
+++ b/package.json
@@ -62,13 +62,13 @@
     "checkout",
     "card-element"
   ],
-  "homepage": "https://github.com/wpkyoto/stripe-pwa-elements#readme",
+  "homepage": "https://github.com/hideokamoto/stripe-pwa-elements#readme",
   "bugs": {
-    "url": "https://github.com/wpkyoto/stripe-pwa-elements/issues"
+    "url": "https://github.com/hideokamoto/stripe-pwa-elements/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/wpkyoto/stripe-pwa-elements.git"
+    "url": "https://github.com/hideokamoto/stripe-pwa-elements.git"
   },
   "publishConfig": {
     "access": "public"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 [![npm version](https://img.shields.io/npm/v/stripe-pwa-elements.svg)](https://www.npmjs.com/package/stripe-pwa-elements)
-[![CI](https://github.com/wpkyoto/stripe-pwa-elements/actions/workflows/ci.yml/badge.svg)](https://github.com/wpkyoto/stripe-pwa-elements/actions/workflows/ci.yml)
-[![license](https://img.shields.io/npm/l/stripe-pwa-elements.svg)](https://github.com/wpkyoto/stripe-pwa-elements/blob/main/LICENSE)
+[![CI](https://github.com/hideokamoto/stripe-pwa-elements/actions/workflows/ci.yml/badge.svg)](https://github.com/hideokamoto/stripe-pwa-elements/actions/workflows/ci.yml)
+[![license](https://img.shields.io/npm/l/stripe-pwa-elements.svg)](https://github.com/hideokamoto/stripe-pwa-elements/blob/main/LICENSE)
 [![npm downloads](https://img.shields.io/npm/dm/stripe-pwa-elements.svg)](https://www.npmjs.com/package/stripe-pwa-elements)
 ![Built With Stencil](https://img.shields.io/badge/-Built%20With%20Stencil-16161d.svg?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE5LjIuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCA1MTIgNTEyIiBzdHlsZT0iZW5hYmxlLWJhY2tncm91bmQ6bmV3IDAgMCA1MTIgNTEyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI%2BCjxzdHlsZSB0eXBlPSJ0ZXh0L2NzcyI%2BCgkuc3Qwe2ZpbGw6I0ZGRkZGRjt9Cjwvc3R5bGU%2BCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik00MjQuNywzNzMuOWMwLDM3LjYtNTUuMSw2OC42LTkyLjcsNjguNkgxODAuNGMtMzcuOSwwLTkyLjctMzAuNy05Mi43LTY4LjZ2LTMuNmgzMzYuOVYzNzMuOXoiLz4KPHBhdGggY2xhc3M9InN0MCIgZD0iTTQyNC43LDI5Mi4xSDE4MC40Yy0zNy42LDAtOTIuNy0zMS05Mi43LTY4LjZ2LTMuNkgzMzJjMzcuNiwwLDkyLjcsMzEsOTIuNyw2OC42VjI5Mi4xeiIvPgo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNNDI0LjcsMTQxLjdIODcuN3YtMy42YzAtMzcuNiw1NC44LTY4LjYsOTIuNy02OC42SDMzMmMzNy45LDAsOTIuNywzMC43LDkyLjcsNjguNlYxNDEuN3oiLz4KPC9zdmc%2BCg%3D%3D&colorA=16161d&style=flat-square)
 
@@ -137,55 +137,55 @@ defineCustomElements();
 
 Stripe Card form with split fields (card number, expiry, CVC).
 
-[Documentation](https://github.com/wpkyoto/stripe-pwa-elements/blob/main/src/components/stripe-card-element/readme.md)
+[Documentation](https://github.com/hideokamoto/stripe-pwa-elements/blob/main/src/components/stripe-card-element/readme.md)
 
 ### `<stripe-payment-element>`
 
 Unified payment form supporting multiple payment methods.
 
-[Documentation](https://github.com/wpkyoto/stripe-pwa-elements/blob/main/src/components/stripe-payment-element/readme.md)
+[Documentation](https://github.com/hideokamoto/stripe-pwa-elements/blob/main/src/components/stripe-payment-element/readme.md)
 
 ### `<stripe-express-checkout-element>`
 
 Express Checkout with Apple Pay, Google Pay, Link, and more.
 
-[Documentation](https://github.com/wpkyoto/stripe-pwa-elements/blob/main/src/components/stripe-express-checkout-element/readme.md)
+[Documentation](https://github.com/hideokamoto/stripe-pwa-elements/blob/main/src/components/stripe-express-checkout-element/readme.md)
 
 ### `<stripe-payment-request-button>`
 
 (Beta) Payment Request API button (Apple Pay / Google Pay).
 
-[Documentation](https://github.com/wpkyoto/stripe-pwa-elements/blob/main/src/components/stripe-payment-request-button/readme.md)
+[Documentation](https://github.com/hideokamoto/stripe-pwa-elements/blob/main/src/components/stripe-payment-request-button/readme.md)
 
 ### `<stripe-address-element>`
 
 Address collection form with autocomplete.
 
-[Documentation](https://github.com/wpkyoto/stripe-pwa-elements/blob/main/src/components/stripe-address-element/readme.md)
+[Documentation](https://github.com/hideokamoto/stripe-pwa-elements/blob/main/src/components/stripe-address-element/readme.md)
 
 ### `<stripe-link-authentication-element>`
 
 Email collection with Stripe Link one-click checkout.
 
-[Documentation](https://github.com/wpkyoto/stripe-pwa-elements/blob/main/src/components/stripe-link-authentication-element/readme.md)
+[Documentation](https://github.com/hideokamoto/stripe-pwa-elements/blob/main/src/components/stripe-link-authentication-element/readme.md)
 
 ### `<stripe-currency-selector>`
 
 Currency selection component.
 
-[Documentation](https://github.com/wpkyoto/stripe-pwa-elements/blob/main/src/components/stripe-currency-selector/readme.md)
+[Documentation](https://github.com/hideokamoto/stripe-pwa-elements/blob/main/src/components/stripe-currency-selector/readme.md)
 
 ### `<stripe-modal>`
 
 Modal wrapper for payment components.
 
-[Documentation](https://github.com/wpkyoto/stripe-pwa-elements/blob/main/src/components/stripe-modal/readme.md)
+[Documentation](https://github.com/hideokamoto/stripe-pwa-elements/blob/main/src/components/stripe-modal/readme.md)
 
 ### `<stripe-card-element-modal>`
 
 Combined Card Element with Modal wrapper.
 
-[Documentation](https://github.com/wpkyoto/stripe-pwa-elements/blob/main/src/components/stripe-card-element-modal/readme.md)
+[Documentation](https://github.com/hideokamoto/stripe-pwa-elements/blob/main/src/components/stripe-card-element-modal/readme.md)
 
 ## Quick Start
 

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ Integrating Stripe from scratch requires wiring up several moving parts. This li
 
 ```html
 <!-- One CDN line registers the custom element -->
-<script type="module" src="https://unpkg.com/stripe-pwa-elements/dist/wpkyoto/stripe-pwa-elements.esm.js"></script>
+<script type="module" src="https://unpkg.com/stripe-pwa-elements/dist/stripe-elements/stripe-elements.esm.js"></script>
 
 <!-- Drop in the element — Stripe.js loading, Elements creation, mounting,
      form submission, and confirmPayment are all handled for you -->
@@ -121,7 +121,7 @@ npm install stripe-pwa-elements
 ### Script tag
 
 ```html
-<script type="module" src="https://unpkg.com/stripe-pwa-elements/dist/wpkyoto/stripe-pwa-elements.esm.js"></script>
+<script type="module" src="https://unpkg.com/stripe-pwa-elements/dist/stripe-elements/stripe-elements.esm.js"></script>
 ```
 
 ### ES Module
@@ -197,7 +197,7 @@ Combined Card Element with Modal wrapper.
   intent-client-secret="pi_xxxxx_secret_xxxxx"
 ></stripe-card-element>
 
-<script type="module" src="https://unpkg.com/stripe-pwa-elements/dist/wpkyoto/stripe-pwa-elements.esm.js"></script>
+<script type="module" src="https://unpkg.com/stripe-pwa-elements/dist/stripe-elements/stripe-elements.esm.js"></script>
 <script>
   customElements.whenDefined('stripe-card-element').then(() => {
     const element = document.querySelector('stripe-card-element');


### PR DESCRIPTION
## Summary
This PR updates all repository references throughout the codebase to reflect the change in repository ownership from `wpkyoto` to `hideokamoto`.

## Key Changes
- Updated GitHub repository URLs in `readme.md` from `wpkyoto` to `hideokamoto` (CI badge, license badge, and all component documentation links)
- Updated CDN script tag references in `readme.md` from `dist/wpkyoto/stripe-pwa-elements.esm.js` to `dist/stripe-elements/stripe-elements.esm.js`
- Updated `package.json` metadata:
  - `unpkg` field: Changed distribution path from `dist/wpkyoto/stripe-pwa-elements.esm.js` to `dist/stripe-elements/stripe-elements.esm.js`
  - `homepage` field: Updated to new repository URL
  - `bugs.url` field: Updated to new repository URL
  - `repository.url` field: Updated to new repository URL

## Implementation Details
All changes are documentation and configuration updates with no impact to the actual component code or functionality. The distribution path change aligns with the Stencil build output structure using the new namespace.

https://claude.ai/code/session_015MNgKTE4YbDEnY2aUfkoyJ