### PR TITLE
Add bundler integration guide for Vite, webpack, and Capacitor

### DIFF
--- a/docs/src/content/docs/en/guides/bundler-integration.md
+++ b/docs/src/content/docs/en/guides/bundler-integration.md
@@ -103,6 +103,7 @@ export default {
 ```
 
 ```javascript
+// index.js
 import 'stripe-pwa-elements/dist/components/stripe-payment-element';
 ```
 

--- a/docs/src/content/docs/en/guides/bundler-integration.md
+++ b/docs/src/content/docs/en/guides/bundler-integration.md
@@ -1,0 +1,131 @@
+---
+title: Bundler Integration (Vite, webpack, Capacitor)
+description: Import components directly from the custom-elements build to avoid runtime dynamic-import failures.
+---
+
+When you use a bundler such as Vite, webpack, or Rollup — including Capacitor
+apps — prefer importing components directly from the **custom-elements build**
+instead of the lazy `defineCustomElements()` loader.
+
+## The problem with the lazy loader
+
+The default install path registers every component through a lazy loader:
+
+```javascript
+import { defineCustomElements } from 'stripe-pwa-elements/loader';
+defineCustomElements();
+```
+
+This loader fetches each component as a separate chunk at runtime via a dynamic
+`import()`. In bundler-based setups the chunk URLs are resolved relative to the
+package's own ESM output, which the bundler does not always serve correctly.
+Under Vite (and Vite-powered Capacitor projects) this commonly surfaces as:
+
+```text
+TypeError: Failed to fetch dynamically imported module
+```
+
+## The fix: import from the custom-elements build
+
+Import the component you need directly from `dist/components`. Each module
+auto-registers its custom element on import, so a bare import is enough:
+
+```javascript
+// Registers <stripe-payment-element> — no defineCustomElements() needed
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+```
+
+Because the import is static, your bundler includes the component in your app
+bundle. There is no runtime dynamic `import()`, so the "Failed to fetch
+dynamically imported module" error cannot occur.
+
+Import only the components you actually use — each one is tree-shakeable:
+
+```javascript
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+import 'stripe-pwa-elements/dist/components/stripe-express-checkout-element';
+```
+
+The element tag names are unchanged, so your markup stays the same:
+
+```html
+<stripe-payment-element
+  publishable-key="pk_test_xxxxx"
+  intent-client-secret="pi_xxxxx_secret_xxxxx"
+></stripe-payment-element>
+```
+
+TypeScript types are still imported from the package root, not from
+`dist/components`:
+
+```ts
+import type { DefaultFormSubmitResult, IntentType } from 'stripe-pwa-elements';
+```
+
+## Bundler-specific setup
+
+### Vite
+
+No special configuration is required — the static imports above work out of the
+box. Add the imports once near your app entry point (e.g. `main.ts`):
+
+```javascript
+// main.ts
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+```
+
+If you previously called `defineCustomElements()`, remove it to avoid
+registering the components twice.
+
+### webpack
+
+webpack resolves the static imports directly; no extra loader configuration is
+needed. Import the components from your entry module:
+
+```javascript
+// index.js
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+```
+
+### Rollup
+
+Rollup bundles the imported components statically. Make sure
+`@rollup/plugin-node-resolve` is enabled so the bare package path resolves:
+
+```javascript
+// rollup.config.mjs
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+
+export default {
+  plugins: [nodeResolve()],
+  // ...
+};
+```
+
+```javascript
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+```
+
+## Capacitor + Vite (recommended setup)
+
+Capacitor's web layer is typically built with Vite, so the lazy loader can hit
+the dynamic-import error described above. Use the direct import instead:
+
+```javascript
+// src/main.ts
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+// add any other components you use
+```
+
+This is the recommended setup for Capacitor apps and for
+[`@capacitor-community/stripe`](https://github.com/capacitor-community/stripe)'s
+web implementation.
+
+## When to use which
+
+| Setup | Recommended import |
+| --- | --- |
+| Plain HTML / no build step | CDN `<script type="module">` |
+| Vite, webpack, Rollup, Capacitor | `stripe-pwa-elements/dist/components/<tag>` |
+
+Both approaches register the same components; only the loading strategy differs.

--- a/docs/src/content/docs/en/guides/index.md
+++ b/docs/src/content/docs/en/guides/index.md
@@ -7,4 +7,5 @@ description: Integration guides.
 
 - [Getting Started](/en/guides/getting-started/)
 - [Payment Flows](/en/guides/payment-flows/)
+- [Bundler Integration (Vite, webpack, Capacitor)](/en/guides/bundler-integration/)
 

--- a/docs/src/content/docs/guides/bundler-integration.md
+++ b/docs/src/content/docs/guides/bundler-integration.md
@@ -100,6 +100,7 @@ export default {
 ```
 
 ```javascript
+// index.js
 import 'stripe-pwa-elements/dist/components/stripe-payment-element';
 ```
 

--- a/docs/src/content/docs/guides/bundler-integration.md
+++ b/docs/src/content/docs/guides/bundler-integration.md
@@ -1,0 +1,128 @@
+---
+title: バンドラ統合（Vite / webpack / Capacitor）
+description: custom-elements ビルドから直接 import して実行時の動的 import 失敗を回避する。
+---
+
+Vite・webpack・Rollup などのバンドラを使う場合（Capacitor アプリを含む）は、
+遅延ローダー `defineCustomElements()` ではなく **custom-elements ビルドからの直接 import** を推奨します。
+
+## 遅延ローダーの問題
+
+通常のインストール手順では、遅延ローダー経由ですべてのコンポーネントを登録します。
+
+```javascript
+import { defineCustomElements } from 'stripe-pwa-elements/loader';
+defineCustomElements();
+```
+
+このローダーは各コンポーネントを実行時に動的 `import()` で別チャンクとして取得します。
+バンドラ環境ではチャンク URL がパッケージ自身の ESM 出力を基準に解決されるため、
+バンドラが正しく配信できないことがあります。Vite（および Vite ベースの Capacitor プロジェクト）では、
+次のエラーとして現れることがよくあります。
+
+```text
+TypeError: Failed to fetch dynamically imported module
+```
+
+## 解決策: custom-elements ビルドから import する
+
+必要なコンポーネントを `dist/components` から直接 import します。
+各モジュールは import 時にカスタム要素を自動登録するため、import するだけで利用できます。
+
+```javascript
+// <stripe-payment-element> を登録 — defineCustomElements() は不要
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+```
+
+import が静的になるため、バンドラがコンポーネントをアプリのバンドルに含めます。
+実行時の動的 `import()` が発生しないので、"Failed to fetch dynamically imported module"
+エラーは起こりません。
+
+実際に使うコンポーネントだけを import してください（それぞれ tree-shaking 可能です）。
+
+```javascript
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+import 'stripe-pwa-elements/dist/components/stripe-express-checkout-element';
+```
+
+要素のタグ名は変わらないため、マークアップはそのままです。
+
+```html
+<stripe-payment-element
+  publishable-key="pk_test_xxxxx"
+  intent-client-secret="pi_xxxxx_secret_xxxxx"
+></stripe-payment-element>
+```
+
+TypeScript の型は `dist/components` からではなく、引き続きパッケージルートから import します。
+
+```ts
+import type { DefaultFormSubmitResult, IntentType } from 'stripe-pwa-elements';
+```
+
+## バンドラ別のセットアップ
+
+### Vite
+
+特別な設定は不要で、上記の静的 import がそのまま動作します。
+アプリのエントリポイント（例: `main.ts`）付近で一度 import してください。
+
+```javascript
+// main.ts
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+```
+
+以前 `defineCustomElements()` を呼んでいた場合は、二重登録を避けるため削除してください。
+
+### webpack
+
+webpack は静的 import を直接解決するため、追加のローダー設定は不要です。
+エントリモジュールからコンポーネントを import します。
+
+```javascript
+// index.js
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+```
+
+### Rollup
+
+Rollup はインポートしたコンポーネントを静的にバンドルします。
+パッケージパスを解決できるよう `@rollup/plugin-node-resolve` を有効にしてください。
+
+```javascript
+// rollup.config.mjs
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+
+export default {
+  plugins: [nodeResolve()],
+  // ...
+};
+```
+
+```javascript
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+```
+
+## Capacitor + Vite（推奨セットアップ）
+
+Capacitor の Web レイヤーは通常 Vite でビルドされるため、遅延ローダーでは上記の
+動的 import エラーに遭遇することがあります。代わりに直接 import を使ってください。
+
+```javascript
+// src/main.ts
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+// 利用する他のコンポーネントも追加
+```
+
+これは Capacitor アプリおよび
+[`@capacitor-community/stripe`](https://github.com/capacitor-community/stripe)
+の Web 実装で推奨されるセットアップです。
+
+## どちらを使うか
+
+| 環境 | 推奨 import |
+| --- | --- |
+| 素の HTML / ビルドなし | CDN `<script type="module">` |
+| Vite / webpack / Rollup / Capacitor | `stripe-pwa-elements/dist/components/<tag>` |
+
+どちらも同じコンポーネントを登録します。読み込み方法が異なるだけです。

--- a/docs/src/content/docs/guides/index.md
+++ b/docs/src/content/docs/guides/index.md
@@ -7,5 +7,6 @@ description: 使い方のガイド。
 
 - [Getting Started](/guides/getting-started/)
 - [決済フロー](/guides/payment-flows/)
+- [バンドラ統合（Vite / webpack / Capacitor）](/guides/bundler-integration/)
 - [stripe-payment-request-button から stripe-express-checkout-element への移行](/guides/migrate-payment-request-button-to-express-checkout/)
 

--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,21 @@ import { defineCustomElements } from 'stripe-pwa-elements/loader';
 defineCustomElements();
 ```
 
+### Bundlers (Vite, webpack, Capacitor)
+
+When using a bundler — including Capacitor apps built with Vite — import the
+components you need directly from the custom-elements build. Each module
+auto-registers its element on import, so no `defineCustomElements()` call is needed:
+
+```javascript
+import 'stripe-pwa-elements/dist/components/stripe-payment-element';
+```
+
+This avoids the runtime dynamic import the lazy `loader` relies on, which can fail
+with `Failed to fetch dynamically imported module` under Vite. See the
+[Bundler Integration guide](https://stripe-pwa-elements-docs.workers.dev/en/guides/bundler-integration/)
+for Vite/webpack/Rollup and Capacitor setup examples.
+
 ## Components
 
 ### `<stripe-card-element>`
@@ -390,7 +405,7 @@ import type {
 } from 'stripe-pwa-elements';
 ```
 
-**Do not** import from internal paths such as `dist/types/interfaces` or `dist-custom-elements/...`. Those paths are implementation details and are not part of the public API — they may change without notice across any release.
+The custom-elements entry `stripe-pwa-elements/dist/components/<tag>` is a supported import path for bundler-based setups (see [Bundlers](#bundlers-vite-webpack-capacitor) above). However, **do not** import from internal paths such as `dist/types/interfaces`. Those paths are implementation details and are not part of the public API — they may change without notice across any release.
 
 ### Semver policy
 

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -28,6 +28,12 @@ export const config: Config = {
     },
     {
       type: 'dist-custom-elements',
+      // Auto-register each component on import so consumers can use a bare
+      // `import 'stripe-pwa-elements/dist/components/<tag>';` in bundler-based
+      // setups (Vite/webpack/Rollup, Capacitor). This avoids the runtime
+      // dynamic-import the lazy `dist` loader relies on, which can fail with
+      // "Failed to fetch dynamically imported module" under Vite.
+      customElementsExportBehavior: 'auto-define-custom-elements',
     },
     {
       type: 'docs-readme',


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and configuration for using stripe-pwa-elements with bundlers (Vite, webpack, Rollup, and Capacitor). It addresses the "Failed to fetch dynamically imported module" error that occurs when using the lazy loader with bundler-based setups by recommending direct imports from the custom-elements build.

## Key Changes

- **New documentation guides** (English and Japanese):
  - `docs/src/content/docs/en/guides/bundler-integration.md` — Complete guide explaining the problem with lazy loaders, the solution using direct imports, and bundler-specific setup instructions for Vite, webpack, Rollup, and Capacitor
  - `docs/src/content/docs/guides/bundler-integration.md` — Japanese translation of the bundler integration guide
  - Updated guide index pages to link to the new bundler integration guide

- **Updated README**:
  - Added "Bundlers (Vite, webpack, Capacitor)" section with quick setup example
  - Clarified that `stripe-pwa-elements/dist/components/<tag>` is a supported import path for bundler-based setups
  - Updated API documentation note to reflect the custom-elements entry point as a public API

- **Stencil configuration**:
  - Modified `stencil.config.ts` to enable `customElementsExportBehavior: 'auto-define-custom-elements'` for the `dist-custom-elements` output target
  - This ensures each component auto-registers its custom element on import, eliminating the need for `defineCustomElements()` calls

## Implementation Details

The fix leverages Stencil's auto-define behavior to make static imports work seamlessly with bundlers. Instead of relying on runtime dynamic imports (which bundlers struggle to resolve correctly), consumers can now import components directly:

```javascript
import 'stripe-pwa-elements/dist/components/stripe-payment-element';
```

This approach:
- Eliminates runtime dynamic import failures under Vite and other bundlers
- Allows tree-shaking of unused components
- Works out-of-the-box with Vite, webpack, Rollup, and Capacitor
- Maintains backward compatibility with the existing lazy loader approach

https://claude.ai/code/session_01PDcvikBySHAbUt87nYbsWS