### PR TITLE
Add StackBlitz demo template for stripe-pwa-elements

### DIFF
--- a/examples/stackblitz/README.md
+++ b/examples/stackblitz/README.md
@@ -50,7 +50,7 @@ two endpoints for this:
 | `POST /api/create-payment-intent` | `{ clientSecret }` |
 | `POST /api/create-checkout-session` | `{ clientSecret }` |
 
-Request body (JSON): `{ "currency": "usd" }` — supported currencies:
+Request body (JSON): `{ "currency": "usd", "publishableKey": "pk_test_…" }` — supported currencies:
 `usd`, `jpy`, `eur`, `gbp`, `aud`. Amount is fixed server-side.
 
 The `helpers.js` module in this directory wraps both endpoints:
@@ -127,9 +127,7 @@ Follow these steps to build a demo for a specific element:
      el.setAttribute('amount', '1099');
      el.setAttribute('currency', 'usd');
      container.appendChild(el);
-
-     await customElements.whenDefined('stripe-express-checkout-element');
-     await el.initStripe(publishableKey);
+     // publishable-key attribute triggers @Watch('publishableKey') → initStripe() automatically
    }
    ```
 

--- a/examples/stackblitz/README.md
+++ b/examples/stackblitz/README.md
@@ -1,0 +1,165 @@
+# stripe-pwa-elements — StackBlitz demos
+
+Interactive demos for [stripe-pwa-elements](https://github.com/hideokamoto/stripe-pwa-elements),
+a web component library for Stripe payment UIs.
+
+All demos use **Method A (static / CDN)**: the library is loaded directly from
+unpkg — no npm install, no bundler, and no build step required.
+
+---
+
+## Quick start
+
+### 1. Get a Stripe test publishable key
+
+1. Log in to the [Stripe Dashboard](https://dashboard.stripe.com).
+2. Switch to **Test mode** (toggle in the top-left corner).
+3. Go to **Developers → API keys**.
+4. Copy the **Publishable key** — it starts with `pk_test_`.
+
+> **Never use a live key (`pk_live_`) in these demos.** The demos are
+> public; live keys must not appear in browser-visible code.
+
+### 2. Open the demo in StackBlitz
+
+Click the link below to open a pre-configured StackBlitz environment:
+
+```
+https://stackblitz.com/github/hideokamoto/stripe-pwa-elements/tree/main/examples/stackblitz
+```
+
+> If you are working on a feature branch, replace `main` with the branch name.
+
+### 3. Enter your key and click "Render"
+
+Paste your `pk_test_` key into the input field and click **Render**.
+The default template renders `<stripe-address-element>`, which does not
+require a clientSecret.
+
+---
+
+## About clientSecrets (payment-element / express-checkout demos)
+
+`stripe-payment-element` and `stripe-express-checkout-element` need a
+**clientSecret** (from a PaymentIntent or a Checkout Session) before they can
+render. The demo API server at `stripe-pwa-elements-docs.workers.dev` provides
+two endpoints for this:
+
+| Endpoint | Returns |
+|---|---|
+| `POST /api/create-payment-intent` | `{ clientSecret }` |
+| `POST /api/create-checkout-session` | `{ clientSecret }` |
+
+Request body (JSON): `{ "currency": "usd" }` — supported currencies:
+`usd`, `jpy`, `eur`, `gbp`, `aud`. Amount is fixed server-side.
+
+The `helpers.js` module in this directory wraps both endpoints:
+
+```js
+import { fetchPaymentIntentClientSecret, fetchCheckoutSessionClientSecret } from './helpers.js';
+
+const clientSecret = await fetchPaymentIntentClientSecret(publishableKey, 'usd');
+```
+
+> **Important:** The demo API server runs under the Stripe test account owned
+> by this project. The `clientSecret` it returns belongs to that account.
+> To confirm a payment end-to-end you must use the matching `pk_test_` key
+> (the one from the project's own Stripe test account). If you are testing
+> with your own Stripe account you need to run your own backend — the library
+> itself is account-agnostic.
+
+---
+
+## Creating a new demo (fork procedure)
+
+Follow these steps to build a demo for a specific element:
+
+### Address element (no clientSecret)
+
+1. Copy `index.html` to a new folder (e.g. `examples/stackblitz-address/`).
+2. Replace the body of `mountDemo()` with:
+   ```js
+   async function mountDemo(publishableKey, container) {
+     const el = document.createElement('stripe-address-element');
+     el.setAttribute('publishable-key', publishableKey);
+     el.setAttribute('mode', 'billing'); // or 'shipping'
+     container.appendChild(el);
+   }
+   ```
+3. No `helpers.js` dependency needed.
+
+### Payment element (needs clientSecret via PaymentIntent)
+
+1. Copy `index.html` and `helpers.js` to a new folder
+   (e.g. `examples/stackblitz-payment-element/`).
+2. Replace `mountDemo()` with:
+   ```js
+   async function mountDemo(publishableKey, container) {
+     const clientSecret = await fetchPaymentIntentClientSecret(publishableKey);
+
+     const el = document.createElement('stripe-payment-element');
+     el.setAttribute('publishable-key', publishableKey);
+     el.setAttribute('intent-client-secret', clientSecret);
+     container.appendChild(el);
+
+     el.addEventListener('defaultFormSubmitResult', ({ detail }) => {
+       if (detail instanceof Error) {
+         console.error('Payment failed', detail);
+       } else {
+         console.log('Payment succeeded', detail);
+       }
+     });
+   }
+   ```
+
+### Express Checkout element (needs clientSecret via PaymentIntent)
+
+1. Copy `index.html` and `helpers.js` to a new folder
+   (e.g. `examples/stackblitz-express-checkout/`).
+2. Replace `mountDemo()` with:
+   ```js
+   async function mountDemo(publishableKey, container) {
+     const clientSecret = await fetchPaymentIntentClientSecret(publishableKey);
+
+     const el = document.createElement('stripe-express-checkout-element');
+     el.setAttribute('publishable-key', publishableKey);
+     el.setAttribute('client-secret', clientSecret);
+     el.setAttribute('amount', '1099');
+     el.setAttribute('currency', 'usd');
+     container.appendChild(el);
+
+     await customElements.whenDefined('stripe-express-checkout-element');
+     await el.initStripe(publishableKey);
+   }
+   ```
+
+### Checkout Session mode (payment-element with Checkout Session)
+
+Same as the payment-element procedure above, but call
+`fetchCheckoutSessionClientSecret()` instead of
+`fetchPaymentIntentClientSecret()`.
+
+---
+
+## Dependency summary
+
+| Demo | clientSecret needed | API call |
+|---|---|---|
+| address-element | No | — |
+| payment-element (PaymentIntent) | Yes | `fetchPaymentIntentClientSecret` |
+| payment-element (Checkout Session) | Yes | `fetchCheckoutSessionClientSecret` |
+| express-checkout-element | Yes | `fetchPaymentIntentClientSecret` |
+
+---
+
+## CDN path reference
+
+```html
+<script
+  type="module"
+  src="https://unpkg.com/stripe-pwa-elements@3.2.0/dist/stripe-elements/stripe-elements.esm.js"
+></script>
+```
+
+The correct path inside the package is `dist/stripe-elements/stripe-elements.esm.js`.
+Any path containing `dist/wpkyoto/` is incorrect and will result in a 404.

--- a/examples/stackblitz/helpers.js
+++ b/examples/stackblitz/helpers.js
@@ -37,7 +37,7 @@ export async function fetchPaymentIntentClientSecret(publishableKey, currency = 
   const res = await fetch(`${DEMO_API_BASE}/create-payment-intent`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ currency }),
+    body: JSON.stringify({ currency, publishableKey }),
   });
 
   if (!res.ok) {
@@ -73,7 +73,7 @@ export async function fetchCheckoutSessionClientSecret(publishableKey, currency 
   const res = await fetch(`${DEMO_API_BASE}/create-checkout-session`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ currency }),
+    body: JSON.stringify({ currency, publishableKey }),
   });
 
   if (!res.ok) {

--- a/examples/stackblitz/helpers.js
+++ b/examples/stackblitz/helpers.js
@@ -30,6 +30,9 @@ const ALLOWED_CURRENCIES = ['usd', 'jpy', 'eur', 'gbp', 'aud'];
  *   stripe-express-checkout-element.
  */
 export async function fetchPaymentIntentClientSecret(publishableKey, currency = 'usd') {
+  if (!publishableKey || !publishableKey.startsWith('pk_test_')) {
+    throw new Error('publishableKey must be a Stripe test publishable key (pk_test_…)');
+  }
   if (!ALLOWED_CURRENCIES.includes(currency)) {
     throw new Error(`Unsupported currency "${currency}". Use one of: ${ALLOWED_CURRENCIES.join(', ')}.`);
   }
@@ -66,6 +69,9 @@ export async function fetchPaymentIntentClientSecret(publishableKey, currency = 
  *   (checkout session mode).
  */
 export async function fetchCheckoutSessionClientSecret(publishableKey, currency = 'usd') {
+  if (!publishableKey || !publishableKey.startsWith('pk_test_')) {
+    throw new Error('publishableKey must be a Stripe test publishable key (pk_test_…)');
+  }
   if (!ALLOWED_CURRENCIES.includes(currency)) {
     throw new Error(`Unsupported currency "${currency}". Use one of: ${ALLOWED_CURRENCIES.join(', ')}.`);
   }

--- a/examples/stackblitz/helpers.js
+++ b/examples/stackblitz/helpers.js
@@ -1,0 +1,91 @@
+/**
+ * helpers.js — Demo API client for stripe-pwa-elements StackBlitz demos.
+ *
+ * The demo server (stripe-pwa-elements-docs.workers.dev) runs in Stripe test
+ * mode and has its own Stripe test account credentials. Its CORS policy allows
+ * requests from stackblitz.com and *.stackblitz.io, so no additional setup is
+ * needed when running demos from StackBlitz.
+ *
+ * Amount is fixed server-side. Only currency can be specified by the caller,
+ * and it must be one of the values in ALLOWED_CURRENCIES.
+ *
+ * IMPORTANT: These helpers return a clientSecret that belongs to the demo
+ * server's Stripe test account. To process a payment end-to-end you must use
+ * the matching publishable key (see README.md). For address-only demos that do
+ * not need a clientSecret, these helpers are not required.
+ */
+
+const DEMO_API_BASE = 'https://stripe-pwa-elements-docs.workers.dev/api';
+
+/** @type {ReadonlyArray<string>} */
+const ALLOWED_CURRENCIES = ['usd', 'jpy', 'eur', 'gbp', 'aud'];
+
+/**
+ * Fetch a PaymentIntent clientSecret from the demo API.
+ *
+ * @param {string} publishableKey  Stripe publishable key used in this demo (pk_test_…).
+ *   Passed to the server for logging/validation; must match the demo server's account.
+ * @param {'usd'|'jpy'|'eur'|'gbp'|'aud'} [currency='usd']  Payment currency.
+ * @returns {Promise<string>}  clientSecret for use with stripe-payment-element or
+ *   stripe-express-checkout-element.
+ */
+export async function fetchPaymentIntentClientSecret(publishableKey, currency = 'usd') {
+  if (!ALLOWED_CURRENCIES.includes(currency)) {
+    throw new Error(`Unsupported currency "${currency}". Use one of: ${ALLOWED_CURRENCIES.join(', ')}.`);
+  }
+
+  const res = await fetch(`${DEMO_API_BASE}/create-payment-intent`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ currency }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`create-payment-intent failed (HTTP ${res.status})${body ? ': ' + body : ''}`);
+  }
+
+  const { clientSecret } = await res.json();
+
+  if (!clientSecret) {
+    throw new Error('create-payment-intent response did not include a clientSecret');
+  }
+
+  return clientSecret;
+}
+
+/**
+ * Fetch a Checkout Session clientSecret from the demo API.
+ *
+ * Use this when mounting stripe-payment-element in Checkout Session mode.
+ *
+ * @param {string} publishableKey  Stripe publishable key used in this demo (pk_test_…).
+ *   Must match the demo server's account.
+ * @param {'usd'|'jpy'|'eur'|'gbp'|'aud'} [currency='usd']  Session currency.
+ * @returns {Promise<string>}  clientSecret for use with stripe-payment-element
+ *   (checkout session mode).
+ */
+export async function fetchCheckoutSessionClientSecret(publishableKey, currency = 'usd') {
+  if (!ALLOWED_CURRENCIES.includes(currency)) {
+    throw new Error(`Unsupported currency "${currency}". Use one of: ${ALLOWED_CURRENCIES.join(', ')}.`);
+  }
+
+  const res = await fetch(`${DEMO_API_BASE}/create-checkout-session`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ currency }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`create-checkout-session failed (HTTP ${res.status})${body ? ': ' + body : ''}`);
+  }
+
+  const { clientSecret } = await res.json();
+
+  if (!clientSecret) {
+    throw new Error('create-checkout-session response did not include a clientSecret');
+  }
+
+  return clientSecret;
+}

--- a/examples/stackblitz/index.html
+++ b/examples/stackblitz/index.html
@@ -9,6 +9,8 @@
     <script
       type="module"
       src="https://unpkg.com/stripe-pwa-elements@3.2.0/dist/stripe-elements/stripe-elements.esm.js"
+      integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
+      crossorigin="anonymous"
     ></script>
 
     <style>

--- a/examples/stackblitz/index.html
+++ b/examples/stackblitz/index.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>stripe-pwa-elements — StackBlitz template</title>
+
+    <!-- Load stripe-pwa-elements via CDN (Method A: static/CDN, no bundler required) -->
+    <script
+      type="module"
+      src="https://unpkg.com/stripe-pwa-elements@3.2.0/dist/stripe-elements/stripe-elements.esm.js"
+    ></script>
+
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 24px;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        background: #f6f9fc;
+        color: #32325d;
+        line-height: 1.6;
+      }
+
+      header {
+        margin-bottom: 24px;
+      }
+
+      header h1 {
+        margin: 0 0 4px;
+        font-size: 1.4rem;
+        color: #32325d;
+      }
+
+      header p {
+        margin: 0;
+        color: #6b7c93;
+        font-size: 0.9rem;
+      }
+
+      .card {
+        background: #fff;
+        border-radius: 8px;
+        box-shadow: 0 2px 8px rgba(50, 50, 93, 0.1);
+        padding: 24px;
+        max-width: 560px;
+      }
+
+      fieldset {
+        border: 1px solid #e6ebf1;
+        border-radius: 6px;
+        padding: 14px 16px;
+        margin: 0 0 16px;
+      }
+
+      legend {
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: #32325d;
+        padding: 0 4px;
+      }
+
+      input[type='text'] {
+        display: block;
+        width: 100%;
+        padding: 8px 10px;
+        border: 1px solid #cfd7df;
+        border-radius: 4px;
+        font-size: 0.95rem;
+        font-family: inherit;
+        color: #32325d;
+        outline: none;
+        transition: border-color 0.15s;
+      }
+
+      input[type='text']:focus {
+        border-color: #635bff;
+        box-shadow: 0 0 0 2px rgba(99, 91, 255, 0.15);
+      }
+
+      small {
+        display: block;
+        margin-top: 6px;
+        font-size: 0.8rem;
+        color: #8898aa;
+      }
+
+      button[type='submit'] {
+        display: block;
+        width: 100%;
+        padding: 12px;
+        background: #635bff;
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+        font-size: 1rem;
+        font-family: inherit;
+        cursor: pointer;
+        transition: background 0.15s;
+      }
+
+      button[type='submit']:hover {
+        background: #5145e5;
+      }
+
+      button[type='submit']:disabled {
+        background: #aab7c4;
+        cursor: not-allowed;
+      }
+
+      #error-msg {
+        margin-top: 12px;
+        padding: 10px 14px;
+        background: #fff0f0;
+        border: 1px solid #f4a8a8;
+        border-radius: 4px;
+        color: #c0392b;
+        font-size: 0.875rem;
+      }
+
+      #demo-container {
+        margin-top: 24px;
+        max-width: 560px;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>stripe-pwa-elements demo</h1>
+      <p>Enter your Stripe test publishable key to render the element.</p>
+    </header>
+
+    <div class="card">
+      <form id="setup-form" novalidate>
+        <fieldset>
+          <legend>Stripe publishable key</legend>
+          <input
+            id="pk-input"
+            type="text"
+            name="publishable-key"
+            placeholder="pk_test_..."
+            autocomplete="off"
+            spellcheck="false"
+          />
+          <small>Must start with <code>pk_test_</code>. Never use a live key here.</small>
+        </fieldset>
+
+        <button type="submit" id="render-btn">Render</button>
+
+        <p id="error-msg" role="alert" hidden></p>
+      </form>
+    </div>
+
+    <!-- Stripe element mounts here -->
+    <div id="demo-container" hidden></div>
+
+    <script type="module">
+      // helpers.js exports are available here for demos that need a clientSecret.
+      // The default mountDemo() does not need them (stripe-address-element is
+      // clientSecret-free), but they are imported so forked demos can use them
+      // without adding another import line.
+      import { fetchPaymentIntentClientSecret, fetchCheckoutSessionClientSecret } from './helpers.js';
+
+      // =====================================================================
+      // EXTENSION POINT
+      // When forking this template to create a new demo, replace the body of
+      // mountDemo() below.
+      //
+      // Parameters:
+      //   publishableKey {string}   – validated pk_test_… key from the form
+      //   container      {HTMLElement} – the #demo-container div (already empty)
+      //
+      // Available helpers (imported above):
+      //   fetchPaymentIntentClientSecret(publishableKey, currency?)
+      //     → Promise<string>  (POST /api/create-payment-intent)
+      //   fetchCheckoutSessionClientSecret(publishableKey, currency?)
+      //     → Promise<string>  (POST /api/create-checkout-session)
+      //
+      // Example — payment-element demo (see docs/fork-procedure.md):
+      //   const clientSecret = await fetchPaymentIntentClientSecret(publishableKey);
+      //   const el = document.createElement('stripe-payment-element');
+      //   el.setAttribute('publishable-key', publishableKey);
+      //   el.setAttribute('intent-client-secret', clientSecret);
+      //   container.appendChild(el);
+      // =====================================================================
+      async function mountDemo(publishableKey, container) {
+        // Default: stripe-address-element (no clientSecret required).
+        // @Watch('publishableKey') in the component triggers initStripe() automatically
+        // once the publishable-key attribute is set.
+        const el = document.createElement('stripe-address-element');
+        el.setAttribute('publishable-key', publishableKey);
+        container.appendChild(el);
+      }
+
+      // ---- form wiring (do not modify below this line in forked demos) ----
+
+      const form = document.getElementById('setup-form');
+      const renderBtn = document.getElementById('render-btn');
+      const errorMsg = document.getElementById('error-msg');
+      const demoContainer = document.getElementById('demo-container');
+
+      function showError(message) {
+        errorMsg.textContent = message;
+        errorMsg.hidden = false;
+      }
+
+      function clearError() {
+        errorMsg.textContent = '';
+        errorMsg.hidden = true;
+      }
+
+      form.addEventListener('submit', async e => {
+        e.preventDefault();
+        clearError();
+
+        const pk = e.target.elements['publishable-key'].value.trim();
+
+        if (!pk.startsWith('pk_test_')) {
+          showError('Please enter a Stripe test publishable key (starts with pk_test_).');
+          return;
+        }
+
+        renderBtn.disabled = true;
+        demoContainer.innerHTML = '';
+        demoContainer.hidden = false;
+
+        try {
+          await mountDemo(pk, demoContainer);
+        } catch (err) {
+          demoContainer.innerHTML = '';
+          demoContainer.hidden = true;
+          showError(`Error: ${err.message}`);
+        } finally {
+          renderBtn.disabled = false;
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

This PR adds a new StackBlitz demo template for stripe-pwa-elements, enabling users to quickly test the library in an interactive browser environment without requiring local setup or a bundler.

## Key Changes

- **`examples/stackblitz/index.html`** — Main demo template that:
  - Loads stripe-pwa-elements from CDN (unpkg, Method A)
  - Provides a form for users to enter their Stripe test publishable key
  - Renders `<stripe-address-element>` by default (no clientSecret required)
  - Includes comprehensive styling and error handling
  - Includes clear extension points for forking to create demos for other elements (payment-element, express-checkout-element, etc.)

- **`examples/stackblitz/helpers.js`** — API client module that:
  - Provides `fetchPaymentIntentClientSecret()` and `fetchCheckoutSessionClientSecret()` helper functions
  - Connects to the demo API server (`stripe-pwa-elements-docs.workers.dev`)
  - Supports multiple currencies (usd, jpy, eur, gbp, aud)
  - Includes comprehensive error handling and validation
  - Enables demos that require a clientSecret (payment-element, express-checkout-element)

- **`examples/stackblitz/README.md`** — Complete documentation covering:
  - Quick start guide for obtaining a Stripe test key and opening the demo
  - Explanation of clientSecret requirements for different elements
  - Detailed fork procedure with code examples for creating demos for:
    - Address element (no clientSecret)
    - Payment element (PaymentIntent mode)
    - Express Checkout element
    - Checkout Session mode
  - Dependency summary table
  - CDN path reference

## Implementation Details

- The template uses **Method A (static/CDN)** — no npm install, bundler, or build step required
- Form validation ensures only test keys (`pk_test_`) are accepted
- The default demo mounts `<stripe-address-element>`, which is clientSecret-free and demonstrates the simplest use case
- Clear comments in `mountDemo()` function mark the extension point for forking
- The demo API server runs under the project's own Stripe test account; users testing with their own account must run their own backend
- CORS policy allows requests from stackblitz.com and *.stackblitz.io domains

https://claude.ai/code/session_011CGKNy9dkYjb4aV98dzjHR