### PR TITLE
Add StackBlitz demo project configuration

### DIFF
--- a/examples/stackblitz/package.json
+++ b/examples/stackblitz/package.json
@@ -2,6 +2,9 @@
   "name": "stripe-pwa-elements-stackblitz-demo",
   "private": true,
   "scripts": {
-    "start": "npx serve . --no-clipboard"
+    "start": "serve . --no-clipboard"
+  },
+  "devDependencies": {
+    "serve": "^14.2.4"
   }
 }

--- a/examples/stackblitz/package.json
+++ b/examples/stackblitz/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "stripe-pwa-elements-stackblitz-demo",
+  "private": true,
+  "scripts": {
+    "start": "npx serve . --no-clipboard"
+  }
+}


### PR DESCRIPTION
## Summary
Added a new StackBlitz demo project configuration to enable quick online experimentation with stripe-pwa-elements without local setup.

## Changes
- Added `examples/stackblitz/package.json` with minimal configuration for a StackBlitz-compatible demo project
- Configured a `start` script using `npx serve` to serve the demo files locally or on StackBlitz
- Set project metadata (`name`, `private` flag) for the demo environment

## Details
This configuration allows developers and users to quickly test stripe-pwa-elements in an online IDE environment (StackBlitz) without requiring local Node.js/pnpm installation. The `serve` package is used as a lightweight HTTP server to host the demo files.

https://claude.ai/code/session_011CGKNy9dkYjb4aV98dzjHR