### PR TITLE
Move jest-circleci-coverage to optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,10 +80,12 @@
   ],
   "author": "Hidetaka Okamoto <info@wp-kyoto.net> (https://wp-kyoto.net)",
   "license": "MIT",
+  "optionalDependencies": {
+    "@jsr/circleci__jest-circleci-coverage": "^0.4.0"
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.39.2",
-    "@jsr/circleci__jest-circleci-coverage": "^0.4.0",
     "@stencil-community/eslint-plugin": "^0.10.0",
     "@stencil/sass": "^3.2.3",
     "@stencil/store": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.4
-      '@jsr/circleci__jest-circleci-coverage':
-        specifier: ^0.4.0
-        version: 0.4.0
       '@stencil-community/eslint-plugin':
         specifier: ^0.10.0
         version: 0.10.0(@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(@typescript-eslint/parser@8.60.1(eslint@9.39.4)(typescript@5.9.3))(eslint-plugin-react@7.37.5(eslint@9.39.4))(eslint@9.39.4)(typescript@5.9.3)
@@ -96,6 +93,10 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+    optionalDependencies:
+      '@jsr/circleci__jest-circleci-coverage':
+        specifier: ^0.4.0
+        version: 0.4.0
 
   docs:
     dependencies:
@@ -7570,6 +7571,7 @@ snapshots:
       jest-message-util: 30.4.1
       jest-util: 30.4.1
       slash: 3.0.0
+    optional: true
 
   '@jest/core@29.7.0':
     dependencies:
@@ -7616,6 +7618,7 @@ snapshots:
       jest-mock: 30.4.1
       jest-util: 30.4.1
       jsdom: 26.1.0
+    optional: true
 
   '@jest/environment@29.7.0':
     dependencies:
@@ -7630,6 +7633,7 @@ snapshots:
       '@jest/types': 30.4.1
       '@types/node': 25.9.1
       jest-mock: 30.4.1
+    optional: true
 
   '@jest/expect-utils@29.7.0':
     dependencies:
@@ -7659,8 +7663,10 @@ snapshots:
       jest-message-util: 30.4.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
+    optional: true
 
-  '@jest/get-type@30.1.0': {}
+  '@jest/get-type@30.1.0':
+    optional: true
 
   '@jest/globals@29.7.0':
     dependencies:
@@ -7675,6 +7681,7 @@ snapshots:
     dependencies:
       '@types/node': 25.9.1
       jest-regex-util: 30.4.0
+    optional: true
 
   '@jest/reporters@29.7.0':
     dependencies:
@@ -7732,6 +7739,7 @@ snapshots:
       v8-to-istanbul: 9.3.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@jest/schemas@29.6.3':
     dependencies:
@@ -7740,6 +7748,7 @@ snapshots:
   '@jest/schemas@30.4.1':
     dependencies:
       '@sinclair/typebox': 0.34.49
+    optional: true
 
   '@jest/source-map@29.6.3':
     dependencies:
@@ -7760,6 +7769,7 @@ snapshots:
       '@jest/types': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.3
+    optional: true
 
   '@jest/test-sequencer@29.7.0':
     dependencies:
@@ -7806,6 +7816,7 @@ snapshots:
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@jest/types@29.6.3':
     dependencies:
@@ -7825,6 +7836,7 @@ snapshots:
       '@types/node': 25.9.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
+    optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -7864,8 +7876,10 @@ snapshots:
       - node-notifier
       - supports-color
       - utf-8-validate
+    optional: true
 
-  '@jsr/circleci__v8-coverage-collector@0.2.0': {}
+  '@jsr/circleci__v8-coverage-collector@0.2.0':
+    optional: true
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -8219,7 +8233,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
-  '@sinclair/typebox@0.34.49': {}
+  '@sinclair/typebox@0.34.49':
+    optional: true
 
   '@sindresorhus/is@7.2.0': {}
 
@@ -8236,6 +8251,7 @@ snapshots:
   '@sinonjs/fake-timers@15.4.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+    optional: true
 
   '@speed-highlight/core@1.2.17': {}
 
@@ -8461,6 +8477,7 @@ snapshots:
       '@types/node': 25.9.1
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
+    optional: true
 
   '@types/json-schema@7.0.15': {}
 
@@ -8508,7 +8525,8 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
-  '@types/tough-cookie@4.0.5': {}
+  '@types/tough-cookie@4.0.5':
+    optional: true
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -9023,6 +9041,7 @@ snapshots:
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
@@ -10199,7 +10218,8 @@ snapshots:
 
   exit-hook@4.0.0: {}
 
-  exit-x@0.2.2: {}
+  exit-x@0.2.2:
+    optional: true
 
   exit@0.1.2: {}
 
@@ -11162,6 +11182,7 @@ snapshots:
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   istanbul-reports@3.2.0:
     dependencies:
@@ -11292,6 +11313,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   jest-environment-node@29.7.0:
     dependencies:
@@ -11311,6 +11333,7 @@ snapshots:
       jest-mock: 30.4.1
       jest-util: 30.4.1
       jest-validate: 30.4.1
+    optional: true
 
   jest-get-type@29.6.3: {}
 
@@ -11344,6 +11367,7 @@ snapshots:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   jest-junit@17.0.0:
     dependencies:
@@ -11388,6 +11412,7 @@ snapshots:
       pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
+    optional: true
 
   jest-mock@29.7.0:
     dependencies:
@@ -11400,6 +11425,7 @@ snapshots:
       '@jest/types': 30.4.1
       '@types/node': 25.9.1
       jest-util: 30.4.1
+    optional: true
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
     optionalDependencies:
@@ -11407,7 +11433,8 @@ snapshots:
 
   jest-regex-util@29.6.3: {}
 
-  jest-regex-util@30.4.0: {}
+  jest-regex-util@30.4.0:
+    optional: true
 
   jest-resolve-dependencies@29.7.0:
     dependencies:
@@ -11523,6 +11550,7 @@ snapshots:
       ci-info: 4.4.0
       graceful-fs: 4.2.11
       picomatch: 4.0.4
+    optional: true
 
   jest-validate@29.7.0:
     dependencies:
@@ -11541,6 +11569,7 @@ snapshots:
       chalk: 4.1.2
       leven: 3.1.0
       pretty-format: 30.4.1
+    optional: true
 
   jest-watcher@29.7.0:
     dependencies:
@@ -11567,6 +11596,7 @@ snapshots:
       jest-util: 30.4.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    optional: true
 
   jest@29.7.0(@types/node@25.9.1):
     dependencies:
@@ -11645,6 +11675,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   jsesc@3.1.0: {}
 
@@ -12864,6 +12895,7 @@ snapshots:
       ansi-styles: 5.2.0
       react-is-18: react-is@18.3.1
       react-is-19: react-is@19.2.7
+    optional: true
 
   prismjs@1.30.0: {}
 
@@ -12963,7 +12995,8 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-is@19.2.7: {}
+  react-is@19.2.7:
+    optional: true
 
   read-package-up@11.0.0:
     dependencies:
@@ -14433,6 +14466,7 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
+    optional: true
 
   ws@8.21.0: {}
 


### PR DESCRIPTION
## Summary
Moved `@jsr/circleci__jest-circleci-coverage` from `devDependencies` to `optionalDependencies` in package.json.

## Changes
- Moved `@jsr/circleci__jest-circleci-coverage` ^0.4.0 from `devDependencies` to newly created `optionalDependencies` section
- This allows the dependency to be installed only when needed (e.g., in CI/CD environments) rather than for all development installations

## Rationale
Making jest-circleci-coverage an optional dependency reduces the installation footprint for local development while maintaining availability in CI/CD pipelines where CircleCI coverage reporting is needed. This is a common pattern for CI-specific tooling that isn't required for everyday development workflows.

https://claude.ai/code/session_015emeeGsjsauA2CJabXQ6tC