### PR TITLE
fix: serve demo publishable key from /api/config and drop broken SRI

### DIFF
--- a/docs/.dev.vars.example
+++ b/docs/.dev.vars.example
@@ -1,2 +1,3 @@
 STRIPE_SECRET_KEY=sk_test_xxx
+STRIPE_PUBLISHABLE_KEY=pk_test_xxx
 ALLOWED_ORIGINS=http://localhost:4321

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,13 +25,33 @@ npm run docs:build
 
 ## Serverless API Endpoints
 
-The docs site exposes two API endpoints that allow demo HTML (e.g. StackBlitz embeds) to obtain a Stripe
-`clientSecret` using only a public `pk_test_` key in the browser. The secret key stays on the server.
+The docs site exposes API endpoints that let demo HTML (e.g. StackBlitz embeds) obtain the demo
+account's public `pk_test_` key and a Stripe `clientSecret`, all without any key in the page source.
+The secret key stays on the server.
 
 > **WARNING**: Only Stripe test keys (`sk_test_*` or `rk_test_*`) are permitted. Never configure a live key (`sk_live_*` / `rk_live_*`).
 > The server validates the key prefix and will refuse to start if a live key is found.
 
 ### Endpoints
+
+#### `GET /api/config`
+
+Returns the demo account's Stripe **publishable** key. Browser demos call this so they never need to
+hardcode or ask the user to paste a key. The returned key belongs to the same account as
+`STRIPE_SECRET_KEY`, so any `clientSecret` from the endpoints below is usable with it (Stripe.js
+requires the publishable key and the `clientSecret` to come from the same account).
+
+**Response** (200):
+
+```json
+{ "publishableKey": "pk_test_xxx" }
+```
+
+**Error responses**:
+- `403` — origin not allowed
+- `500` — `STRIPE_PUBLISHABLE_KEY` not configured or not a `pk_test_` key
+
+---
 
 #### `POST /api/create-payment-intent`
 
@@ -121,8 +141,12 @@ entries are no longer trusted unless you include them). Each entry may be an exa
 
    ```bash
    STRIPE_SECRET_KEY=sk_test_or_rk_test_your_key_here
+   STRIPE_PUBLISHABLE_KEY=pk_test_your_publishable_key_here
    ALLOWED_ORIGINS=http://localhost:4321
    ```
+
+   `STRIPE_PUBLISHABLE_KEY` must be the **publishable** key from the **same Stripe account** as the
+   secret key above. The `/api/config` endpoint serves it to browser demos.
 
    The `@astrojs/cloudflare` adapter reads `.dev.vars` automatically during `astro dev` — no extra
    configuration is needed.
@@ -142,7 +166,13 @@ Set the secret via Wrangler — never commit it to the repository:
 ```bash
 wrangler secret put STRIPE_SECRET_KEY
 # When prompted, paste your sk_test_ or rk_test_ key
+
+wrangler secret put STRIPE_PUBLISHABLE_KEY
+# When prompted, paste the pk_test_ key from the SAME Stripe account
 ```
+
+> The publishable key is public by design, so it can also be set as a plain `var` instead of a secret
+> if you prefer. It must belong to the same account as `STRIPE_SECRET_KEY`.
 
 Then deploy:
 

--- a/docs/src/env.d.ts
+++ b/docs/src/env.d.ts
@@ -3,6 +3,7 @@
 declare namespace Cloudflare {
   interface Env {
     STRIPE_SECRET_KEY: string;
+    STRIPE_PUBLISHABLE_KEY?: string;
     ALLOWED_ORIGINS?: string;
   }
 }

--- a/docs/src/lib/api-helpers.ts
+++ b/docs/src/lib/api-helpers.ts
@@ -26,6 +26,7 @@ const DEFAULT_ALLOWED_ORIGINS = [
 /** Minimal env shape needed by API helpers. */
 export interface ApiEnv {
   STRIPE_SECRET_KEY: string;
+  STRIPE_PUBLISHABLE_KEY?: string;
   ALLOWED_ORIGINS?: string;
 }
 
@@ -74,7 +75,7 @@ export function corsHeaders(origin: string | null, env: ApiEnv): Record<string, 
   }
   return {
     'Access-Control-Allow-Origin': origin as string,
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     'Access-Control-Max-Age': '86400',
     Vary: 'Origin',
@@ -120,4 +121,24 @@ export function getStripe(env: ApiEnv): Stripe {
     apiVersion: '2026-05-27.dahlia',
   });
   return cachedStripe;
+}
+
+/**
+ * Returns the demo account's publishable key from the environment.
+ *
+ * Publishable keys are public by design, so exposing this value to the browser is safe.
+ * Serving it from the same account as STRIPE_SECRET_KEY guarantees that the publishable
+ * key and any clientSecret created by the demo endpoints belong to the same Stripe account,
+ * which Stripe.js requires (a clientSecret cannot be used with a key from another account).
+ * Throws (without leaking the value) if the key is missing or is not a test publishable key.
+ */
+export function getPublishableKey(env: ApiEnv): string {
+  const key = env.STRIPE_PUBLISHABLE_KEY;
+  if (!key) {
+    throw new Error('STRIPE_PUBLISHABLE_KEY is not configured.');
+  }
+  if (!key.startsWith('pk_test_')) {
+    throw new Error('Only Stripe test publishable keys (pk_test_) are allowed.');
+  }
+  return key;
 }

--- a/docs/src/pages/api/config.ts
+++ b/docs/src/pages/api/config.ts
@@ -1,0 +1,36 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+import { corsHeaders, isAllowedOrigin, json, getPublishableKey } from '../../lib/api-helpers';
+
+export const prerender = false;
+
+export const OPTIONS: APIRoute = ({ request }) => {
+  const origin = request.headers.get('origin');
+  const headers = corsHeaders(origin, env);
+  return new Response(null, { status: 204, headers });
+};
+
+/**
+ * Returns the demo account's Stripe publishable key so browser demos (e.g. StackBlitz embeds)
+ * can render elements without hardcoding or asking the user to paste a key. The returned key
+ * belongs to the same account as STRIPE_SECRET_KEY, so any clientSecret created by the
+ * create-payment-intent / create-checkout-session endpoints is usable with it.
+ */
+export const GET: APIRoute = ({ request }) => {
+  const origin = request.headers.get('origin');
+  const cors = corsHeaders(origin, env);
+
+  // Reject disallowed (or missing) origins before returning anything.
+  if (!isAllowedOrigin(origin, env)) {
+    return json({ error: 'Origin is not allowed.' }, 403, cors);
+  }
+
+  let publishableKey: string;
+  try {
+    publishableKey = getPublishableKey(env);
+  } catch {
+    return json({ error: 'Server configuration error.' }, 500, cors);
+  }
+
+  return json({ publishableKey }, 200, cors);
+};

--- a/docs/src/pages/api/config.ts
+++ b/docs/src/pages/api/config.ts
@@ -28,7 +28,10 @@ export const GET: APIRoute = ({ request }) => {
   let publishableKey: string;
   try {
     publishableKey = getPublishableKey(env);
-  } catch {
+  } catch (error) {
+    // Logged to the Worker logs (not the response) to aid debugging a missing/invalid
+    // STRIPE_PUBLISHABLE_KEY. The error message never contains the key value.
+    console.error('Failed to retrieve publishable key:', error);
     return json({ error: 'Server configuration error.' }, 500, cors);
   }
 

--- a/docs/src/pages/api/create-checkout-session.ts
+++ b/docs/src/pages/api/create-checkout-session.ts
@@ -42,7 +42,9 @@ export const POST: APIRoute = async ({ request }) => {
   let stripe: ReturnType<typeof getStripe>;
   try {
     stripe = getStripe(env);
-  } catch {
+  } catch (error) {
+    // Logged to the Worker logs (not the response) to aid debugging configuration issues.
+    console.error('Stripe configuration error:', error);
     return json({ error: 'Server configuration error.' }, 500, cors);
   }
 
@@ -71,7 +73,8 @@ export const POST: APIRoute = async ({ request }) => {
     });
 
     return json({ clientSecret: session.client_secret }, 200, cors);
-  } catch {
+  } catch (error) {
+    console.error('Failed to create Checkout Session:', error);
     return json({ error: 'Failed to create Checkout Session.' }, 500, cors);
   }
 };

--- a/docs/src/pages/api/create-payment-intent.ts
+++ b/docs/src/pages/api/create-payment-intent.ts
@@ -40,7 +40,9 @@ export const POST: APIRoute = async ({ request }) => {
   let stripe: ReturnType<typeof getStripe>;
   try {
     stripe = getStripe(env);
-  } catch {
+  } catch (error) {
+    // Logged to the Worker logs (not the response) to aid debugging configuration issues.
+    console.error('Stripe configuration error:', error);
     return json({ error: 'Server configuration error.' }, 500, cors);
   }
 
@@ -52,7 +54,8 @@ export const POST: APIRoute = async ({ request }) => {
     });
 
     return json({ clientSecret: paymentIntent.client_secret }, 200, cors);
-  } catch {
+  } catch (error) {
+    console.error('Failed to create PaymentIntent:', error);
     return json({ error: 'Failed to create PaymentIntent.' }, 500, cors);
   }
 };

--- a/examples/stackblitz/README.md
+++ b/examples/stackblitz/README.md
@@ -10,17 +10,7 @@ unpkg — no npm install, no bundler, and no build step required.
 
 ## Quick start
 
-### 1. Get a Stripe test publishable key
-
-1. Log in to the [Stripe Dashboard](https://dashboard.stripe.com).
-2. Switch to **Test mode** (toggle in the top-left corner).
-3. Go to **Developers → API keys**.
-4. Copy the **Publishable key** — it starts with `pk_test_`.
-
-> **Never use a live key (`pk_live_`) in these demos.** The demos are
-> public; live keys must not appear in browser-visible code.
-
-### 2. Open the demo in StackBlitz
+### 1. Open the demo in StackBlitz
 
 Click the link below to open a pre-configured StackBlitz environment:
 
@@ -30,49 +20,56 @@ https://stackblitz.com/github/hideokamoto/stripe-pwa-elements/tree/main/examples
 
 > If you are working on a feature branch, replace `main` with the branch name.
 
-### 3. Enter your key and click "Render"
+### 2. Click "Render"
 
-Paste your `pk_test_` key into the input field and click **Render**.
-The default template renders `<stripe-address-element>`, which does not
-require a clientSecret.
+You do **not** need to provide a Stripe key. On load the demo fetches the demo
+account's publishable key from the demo server (`/api/config`) and renders the
+element when you click **Render**. The default template renders
+`<stripe-address-element>`, which does not require a clientSecret.
 
 ---
 
-## About clientSecrets (payment-element / express-checkout demos)
+## Why the key comes from the server (important)
 
-`stripe-payment-element` and `stripe-express-checkout-element` need a
-**clientSecret** (from a PaymentIntent or a Checkout Session) before they can
-render. The demo API server at `stripe-pwa-elements-docs.workers.dev` provides
-two endpoints for this:
+A `clientSecret` (PaymentIntent / Checkout Session) is tied to the Stripe account
+that created it. **Stripe.js only accepts a `clientSecret` together with a publishable
+key from the same account.** Because the demo server owns the secret key, it must
+also serve the matching publishable key — otherwise payment/express-checkout demos
+could never be confirmed.
 
-| Endpoint | Returns |
-|---|---|
-| `POST /api/create-payment-intent` | `{ clientSecret }` |
-| `POST /api/create-checkout-session` | `{ clientSecret }` |
+That is why these demos fetch the key from `/api/config` instead of asking you to
+paste your own `pk_test_` (which would belong to a different account and would be
+rejected the moment a `clientSecret` is involved).
 
-Request body (JSON): `{ "currency": "usd", "publishableKey": "pk_test_…" }` — supported currencies:
-`usd`, `jpy`, `eur`, `gbp`, `aud`. Amount is fixed server-side.
+| Endpoint | Method | Returns |
+|---|---|---|
+| `/api/config` | `GET` | `{ publishableKey }` (demo account, `pk_test_…`) |
+| `/api/create-payment-intent` | `POST` | `{ clientSecret }` |
+| `/api/create-checkout-session` | `POST` | `{ clientSecret }` |
 
-The `helpers.js` module in this directory wraps both endpoints:
+Request body for the two `POST` endpoints (JSON): `{ "currency": "usd" }` — supported
+currencies: `usd`, `jpy`, `eur`, `gbp`, `aud`. Amount is fixed server-side.
+
+The `helpers.js` module in this directory wraps all three endpoints:
 
 ```js
-import { fetchPaymentIntentClientSecret, fetchCheckoutSessionClientSecret } from './helpers.js';
+import { fetchPublishableKey, fetchPaymentIntentClientSecret, fetchCheckoutSessionClientSecret } from './helpers.js';
 
-const clientSecret = await fetchPaymentIntentClientSecret(publishableKey, 'usd');
+const publishableKey = await fetchPublishableKey();
+const clientSecret = await fetchPaymentIntentClientSecret('usd');
 ```
 
-> **Important:** The demo API server runs under the Stripe test account owned
-> by this project. The `clientSecret` it returns belongs to that account.
-> To confirm a payment end-to-end you must use the matching `pk_test_` key
-> (the one from the project's own Stripe test account). If you are testing
-> with your own Stripe account you need to run your own backend — the library
-> itself is account-agnostic.
+> **Maintainers:** the demo server must have `STRIPE_PUBLISHABLE_KEY` configured with the
+> `pk_test_` key from the **same** Stripe account as `STRIPE_SECRET_KEY`. See
+> [`docs/README.md`](../../docs/README.md) → *Serverless API Endpoints*. Until it is set,
+> `/api/config` returns a 500 and the demo shows a "Could not load the demo key" message.
 
 ---
 
 ## Creating a new demo (fork procedure)
 
-Follow these steps to build a demo for a specific element:
+Follow these steps to build a demo for a specific element. In every case
+`mountDemo(publishableKey, container)` already receives the fetched key.
 
 ### Address element (no clientSecret)
 
@@ -86,7 +83,7 @@ Follow these steps to build a demo for a specific element:
      container.appendChild(el);
    }
    ```
-3. No `helpers.js` dependency needed.
+3. No `helpers.js` clientSecret call needed (the key fetch is already wired in `index.html`).
 
 ### Payment element (needs clientSecret via PaymentIntent)
 
@@ -95,7 +92,7 @@ Follow these steps to build a demo for a specific element:
 2. Replace `mountDemo()` with:
    ```js
    async function mountDemo(publishableKey, container) {
-     const clientSecret = await fetchPaymentIntentClientSecret(publishableKey);
+     const clientSecret = await fetchPaymentIntentClientSecret();
 
      const el = document.createElement('stripe-payment-element');
      el.setAttribute('publishable-key', publishableKey);
@@ -119,12 +116,12 @@ Follow these steps to build a demo for a specific element:
 2. Replace `mountDemo()` with:
    ```js
    async function mountDemo(publishableKey, container) {
-     const clientSecret = await fetchPaymentIntentClientSecret(publishableKey);
+     const clientSecret = await fetchPaymentIntentClientSecret();
 
      const el = document.createElement('stripe-express-checkout-element');
      el.setAttribute('publishable-key', publishableKey);
      el.setAttribute('client-secret', clientSecret);
-     el.setAttribute('amount', '1099');
+     el.setAttribute('amount', '1000');
      el.setAttribute('currency', 'usd');
      container.appendChild(el);
      // publishable-key attribute triggers @Watch('publishableKey') → initStripe() automatically
@@ -141,12 +138,12 @@ Same as the payment-element procedure above, but call
 
 ## Dependency summary
 
-| Demo | clientSecret needed | API call |
+| Demo | clientSecret needed | API calls |
 |---|---|---|
-| address-element | No | — |
-| payment-element (PaymentIntent) | Yes | `fetchPaymentIntentClientSecret` |
-| payment-element (Checkout Session) | Yes | `fetchCheckoutSessionClientSecret` |
-| express-checkout-element | Yes | `fetchPaymentIntentClientSecret` |
+| address-element | No | `fetchPublishableKey` |
+| payment-element (PaymentIntent) | Yes | `fetchPublishableKey` + `fetchPaymentIntentClientSecret` |
+| payment-element (Checkout Session) | Yes | `fetchPublishableKey` + `fetchCheckoutSessionClientSecret` |
+| express-checkout-element | Yes | `fetchPublishableKey` + `fetchPaymentIntentClientSecret` |
 
 ---
 
@@ -156,8 +153,14 @@ Same as the payment-element procedure above, but call
 <script
   type="module"
   src="https://unpkg.com/stripe-pwa-elements@3.2.0/dist/stripe-elements/stripe-elements.esm.js"
+  crossorigin="anonymous"
 ></script>
 ```
 
 The correct path inside the package is `dist/stripe-elements/stripe-elements.esm.js`.
 Any path containing `dist/wpkyoto/` is incorrect and will result in a 404.
+
+> **SRI note:** an `integrity` hash is intentionally **not** used here. The Stencil ESM
+> entry is a loader that dynamically imports separately-hashed chunks, which an integrity
+> hash on the entry tag would not cover — so it adds breakage risk without protecting the
+> component code. The pinned `@3.2.0` version is the integrity anchor instead.

--- a/examples/stackblitz/helpers.js
+++ b/examples/stackblitz/helpers.js
@@ -2,17 +2,19 @@
  * helpers.js — Demo API client for stripe-pwa-elements StackBlitz demos.
  *
  * The demo server (stripe-pwa-elements-docs.workers.dev) runs in Stripe test
- * mode and has its own Stripe test account credentials. Its CORS policy allows
+ * mode and holds its own Stripe test account credentials. Its CORS policy allows
  * requests from stackblitz.com and *.stackblitz.io, so no additional setup is
  * needed when running demos from StackBlitz.
  *
+ * Why the publishable key comes from the server:
+ * A clientSecret (PaymentIntent / Checkout Session) is tied to the Stripe account
+ * that created it. Stripe.js only accepts a clientSecret together with a publishable
+ * key from the SAME account. Because the demo server owns the secret key, it must
+ * also provide the matching publishable key — so demos fetch it via fetchPublishableKey()
+ * instead of asking the user to paste one (which would belong to a different account).
+ *
  * Amount is fixed server-side. Only currency can be specified by the caller,
  * and it must be one of the values in ALLOWED_CURRENCIES.
- *
- * IMPORTANT: These helpers return a clientSecret that belongs to the demo
- * server's Stripe test account. To process a payment end-to-end you must use
- * the matching publishable key (see README.md). For address-only demos that do
- * not need a clientSecret, these helpers are not required.
  */
 
 const DEMO_API_BASE = 'https://stripe-pwa-elements-docs.workers.dev/api';
@@ -21,18 +23,44 @@ const DEMO_API_BASE = 'https://stripe-pwa-elements-docs.workers.dev/api';
 const ALLOWED_CURRENCIES = ['usd', 'jpy', 'eur', 'gbp', 'aud'];
 
 /**
+ * Fetch the demo account's publishable key from the demo API.
+ *
+ * This is the key every demo should use: it matches the account that issues the
+ * clientSecrets below, so payments can be confirmed end-to-end with Stripe test cards.
+ *
+ * @returns {Promise<string>}  A pk_test_… publishable key.
+ */
+export async function fetchPublishableKey() {
+  const res = await fetch(`${DEMO_API_BASE}/config`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`config failed (HTTP ${res.status})${body ? ': ' + body : ''}`);
+  }
+
+  const { publishableKey } = await res.json();
+
+  if (!publishableKey || !publishableKey.startsWith('pk_test_')) {
+    throw new Error('config response did not include a valid pk_test_ publishable key');
+  }
+
+  return publishableKey;
+}
+
+/**
  * Fetch a PaymentIntent clientSecret from the demo API.
  *
- * @param {string} publishableKey  Stripe publishable key used in this demo (pk_test_…).
- *   Passed to the server for logging/validation; must match the demo server's account.
+ * The PaymentIntent is created with the demo server's secret key, so pair the returned
+ * clientSecret with the publishable key from fetchPublishableKey() (same account).
+ *
  * @param {'usd'|'jpy'|'eur'|'gbp'|'aud'} [currency='usd']  Payment currency.
  * @returns {Promise<string>}  clientSecret for use with stripe-payment-element or
  *   stripe-express-checkout-element.
  */
-export async function fetchPaymentIntentClientSecret(publishableKey, currency = 'usd') {
-  if (!publishableKey || !publishableKey.startsWith('pk_test_')) {
-    throw new Error('publishableKey must be a Stripe test publishable key (pk_test_…)');
-  }
+export async function fetchPaymentIntentClientSecret(currency = 'usd') {
   if (!ALLOWED_CURRENCIES.includes(currency)) {
     throw new Error(`Unsupported currency "${currency}". Use one of: ${ALLOWED_CURRENCIES.join(', ')}.`);
   }
@@ -40,7 +68,7 @@ export async function fetchPaymentIntentClientSecret(publishableKey, currency = 
   const res = await fetch(`${DEMO_API_BASE}/create-payment-intent`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ currency, publishableKey }),
+    body: JSON.stringify({ currency }),
   });
 
   if (!res.ok) {
@@ -60,18 +88,14 @@ export async function fetchPaymentIntentClientSecret(publishableKey, currency = 
 /**
  * Fetch a Checkout Session clientSecret from the demo API.
  *
- * Use this when mounting stripe-payment-element in Checkout Session mode.
+ * Use this when mounting stripe-payment-element in Checkout Session mode. Pair the returned
+ * clientSecret with the publishable key from fetchPublishableKey() (same account).
  *
- * @param {string} publishableKey  Stripe publishable key used in this demo (pk_test_…).
- *   Must match the demo server's account.
  * @param {'usd'|'jpy'|'eur'|'gbp'|'aud'} [currency='usd']  Session currency.
  * @returns {Promise<string>}  clientSecret for use with stripe-payment-element
  *   (checkout session mode).
  */
-export async function fetchCheckoutSessionClientSecret(publishableKey, currency = 'usd') {
-  if (!publishableKey || !publishableKey.startsWith('pk_test_')) {
-    throw new Error('publishableKey must be a Stripe test publishable key (pk_test_…)');
-  }
+export async function fetchCheckoutSessionClientSecret(currency = 'usd') {
   if (!ALLOWED_CURRENCIES.includes(currency)) {
     throw new Error(`Unsupported currency "${currency}". Use one of: ${ALLOWED_CURRENCIES.join(', ')}.`);
   }
@@ -79,7 +103,7 @@ export async function fetchCheckoutSessionClientSecret(publishableKey, currency 
   const res = await fetch(`${DEMO_API_BASE}/create-checkout-session`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ currency, publishableKey }),
+    body: JSON.stringify({ currency }),
   });
 
   if (!res.ok) {

--- a/examples/stackblitz/index.html
+++ b/examples/stackblitz/index.html
@@ -5,11 +5,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>stripe-pwa-elements — StackBlitz template</title>
 
-    <!-- Load stripe-pwa-elements via CDN (Method A: static/CDN, no bundler required) -->
+    <!--
+      Load stripe-pwa-elements via CDN (Method A: static/CDN, no bundler required).
+      The version is pinned to @3.2.0 so the bytes are immutable on unpkg. SRI (integrity)
+      is intentionally omitted: the Stencil ESM entry is a loader that dynamically imports
+      separately-hashed chunks which an integrity hash on this tag would not cover, so it
+      adds fragility without protecting the actual component code.
+    -->
     <script
       type="module"
       src="https://unpkg.com/stripe-pwa-elements@3.2.0/dist/stripe-elements/stripe-elements.esm.js"
-      integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb"
       crossorigin="anonymous"
     ></script>
 
@@ -134,39 +139,32 @@
   <body>
     <header>
       <h1>stripe-pwa-elements demo</h1>
-      <p>Enter your Stripe test publishable key to render the element.</p>
+      <p>This demo uses the project's shared Stripe test account — just click Render.</p>
     </header>
 
     <div class="card">
-      <form id="setup-form" novalidate>
-        <fieldset>
-          <legend>Stripe publishable key</legend>
-          <input
-            id="pk-input"
-            type="text"
-            name="publishable-key"
-            placeholder="pk_test_..."
-            autocomplete="off"
-            spellcheck="false"
-          />
-          <small>Must start with <code>pk_test_</code>. Never use a live key here.</small>
-        </fieldset>
+      <fieldset>
+        <legend>Demo publishable key</legend>
+        <p id="key-status">Loading demo key…</p>
+        <small>
+          Fetched from the demo server (<code>/api/config</code>) so it matches the account that
+          issues the payment <code>clientSecret</code>s. No key entry required.
+        </small>
+      </fieldset>
 
-        <button type="submit" id="render-btn">Render</button>
+      <button type="button" id="render-btn" disabled>Render</button>
 
-        <p id="error-msg" role="alert" hidden></p>
-      </form>
+      <p id="error-msg" role="alert" hidden></p>
     </div>
 
     <!-- Stripe element mounts here -->
     <div id="demo-container" hidden></div>
 
     <script type="module">
-      // helpers.js exports are available here for demos that need a clientSecret.
-      // The default mountDemo() does not need them (stripe-address-element is
-      // clientSecret-free), but they are imported so forked demos can use them
-      // without adding another import line.
-      import { fetchPaymentIntentClientSecret, fetchCheckoutSessionClientSecret } from './helpers.js';
+      // helpers.js provides the demo publishable key and (for payment demos) clientSecrets.
+      // The default mountDemo() only needs the publishable key, but the clientSecret helpers
+      // are imported so forked demos can use them without adding another import line.
+      import { fetchPublishableKey, fetchPaymentIntentClientSecret, fetchCheckoutSessionClientSecret } from './helpers.js';
 
       // =====================================================================
       // EXTENSION POINT
@@ -174,17 +172,17 @@
       // mountDemo() below.
       //
       // Parameters:
-      //   publishableKey {string}   – validated pk_test_… key from the form
+      //   publishableKey {string}      – demo account's pk_test_… key (already fetched)
       //   container      {HTMLElement} – the #demo-container div (already empty)
       //
       // Available helpers (imported above):
-      //   fetchPaymentIntentClientSecret(publishableKey, currency?)
+      //   fetchPaymentIntentClientSecret(currency?)
       //     → Promise<string>  (POST /api/create-payment-intent)
-      //   fetchCheckoutSessionClientSecret(publishableKey, currency?)
+      //   fetchCheckoutSessionClientSecret(currency?)
       //     → Promise<string>  (POST /api/create-checkout-session)
       //
-      // Example — payment-element demo (see docs/fork-procedure.md):
-      //   const clientSecret = await fetchPaymentIntentClientSecret(publishableKey);
+      // Example — payment-element demo (see README.md):
+      //   const clientSecret = await fetchPaymentIntentClientSecret();
       //   const el = document.createElement('stripe-payment-element');
       //   el.setAttribute('publishable-key', publishableKey);
       //   el.setAttribute('intent-client-secret', clientSecret);
@@ -199,12 +197,14 @@
         container.appendChild(el);
       }
 
-      // ---- form wiring (do not modify below this line in forked demos) ----
+      // ---- wiring (do not modify below this line in forked demos) ----
 
-      const form = document.getElementById('setup-form');
       const renderBtn = document.getElementById('render-btn');
+      const keyStatus = document.getElementById('key-status');
       const errorMsg = document.getElementById('error-msg');
       const demoContainer = document.getElementById('demo-container');
+
+      let publishableKey = null;
 
       function showError(message) {
         errorMsg.textContent = message;
@@ -216,23 +216,37 @@
         errorMsg.hidden = true;
       }
 
-      form.addEventListener('submit', async e => {
-        e.preventDefault();
-        clearError();
+      // Mask all but the last 4 characters so the key is recognizable but not fully echoed.
+      function maskKey(key) {
+        return key.length > 12 ? `${key.slice(0, 8)}…${key.slice(-4)}` : key;
+      }
 
-        const pk = e.target.elements['publishable-key'].value.trim();
+      // Fetch the demo publishable key on load so the user only has to click Render.
+      (async () => {
+        try {
+          publishableKey = await fetchPublishableKey();
+          keyStatus.textContent = `Using demo key: ${maskKey(publishableKey)}`;
+          renderBtn.disabled = false;
+        } catch (err) {
+          keyStatus.textContent = 'Could not load the demo key.';
+          showError(
+            `${err.message} — the demo server must have STRIPE_PUBLISHABLE_KEY configured ` +
+              '(see examples/stackblitz/README.md).',
+          );
+        }
+      })();
 
-        if (!pk.startsWith('pk_test_')) {
-          showError('Please enter a Stripe test publishable key (starts with pk_test_).');
+      renderBtn.addEventListener('click', async () => {
+        if (!publishableKey) {
           return;
         }
-
+        clearError();
         renderBtn.disabled = true;
         demoContainer.innerHTML = '';
         demoContainer.hidden = false;
 
         try {
-          await mountDemo(pk, demoContainer);
+          await mountDemo(publishableKey, demoContainer);
         } catch (err) {
           demoContainer.innerHTML = '';
           demoContainer.hidden = true;


### PR DESCRIPTION
## Summary

The StackBlitz demo template did not render, and the underlying account model was broken for payment flows. This PR fixes both.

### 1. Demo did not render — broken SRI hash

The CDN `<script>` tag carried a placeholder SRI digest (the MDN example hash), so the browser **blocked the unpkg bundle** and no custom elements were ever defined — the preview stayed blank.

- Removed the `integrity` attribute and rely on the pinned `@3.2.0` version as the integrity anchor.
- SRI on the Stencil ESM entry only covers the loader, not the lazy-loaded component chunks it imports, so it added fragility without protecting the actual component code.

### 2. Publishable key / clientSecret account mismatch

A `clientSecret` (PaymentIntent / Checkout Session) is tied to the Stripe account that created it, and **Stripe.js only accepts it alongside a publishable key from the same account**. Asking the user to paste their own `pk_test_` key therefore could never confirm a payment or express-checkout demo. This follows the Stripe-samples pattern instead:

- **New `GET /api/config`** endpoint returns the demo account's publishable key from a new `STRIPE_PUBLISHABLE_KEY` env var (validated as `pk_test_`).
- `helpers.js` gains `fetchPublishableKey()`; the clientSecret helpers drop the unused `publishableKey` argument the server never read.
- `index.html` fetches the key on load and renders on a single click — no key entry, guaranteeing the key and clientSecret share one account.
- Documented the new endpoint and env var in `docs/README.md`, `.dev.vars.example`, `env.d.ts`, and the demo README.

## Deployment note (required before the demo works)

The deployed Worker must have `STRIPE_PUBLISHABLE_KEY` set to the `pk_test_` key from the **same** Stripe account as `STRIPE_SECRET_KEY`:

```bash
cd docs
wrangler secret put STRIPE_PUBLISHABLE_KEY
pnpm run deploy
```

Until it is set, `/api/config` returns 500 and the demo shows "Could not load the demo key".

## Test plan

- [ ] Set `STRIPE_PUBLISHABLE_KEY` and deploy the docs Worker
- [ ] Open the StackBlitz template, click **Render** → `stripe-address-element` renders without entering a key
- [ ] Verify the unpkg bundle loads (no SRI block in the console)
- [ ] `GET /api/config` returns `{ publishableKey: "pk_test_…" }` from an allowed origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011CGKNy9dkYjb4aV98dzjHR)_