### PR TITLE
fix: allow *.webcontainer.io in CORS allowlist for StackBlitz demos

### DIFF
--- a/docs/src/lib/api-helpers.ts
+++ b/docs/src/lib/api-helpers.ts
@@ -21,6 +21,8 @@ const DEFAULT_ALLOWED_ORIGINS = [
   // Wildcard: any StackBlitz preview subdomain (e.g. https://abc123.stackblitz.io).
   // Entries beginning with `*.` are matched as a host suffix (see matchesOrigin).
   '*.stackblitz.io',
+  // StackBlitz WebContainer previews (served via `serve`) use *.webcontainer.io.
+  '*.webcontainer.io',
 ];
 
 /** Minimal env shape needed by API helpers. */


### PR DESCRIPTION
## Summary

- StackBlitz's WebContainer environment serves `serve`-based previews from `*.webcontainer.io` subdomains, not `*.stackblitz.io`
- Requests from those origins were rejected by the Worker's CORS allowlist, causing a `NetworkError` in the demo (`fetchPublishableKey` silently failed)
- Added `*.webcontainer.io` to `DEFAULT_ALLOWED_ORIGINS` in `docs/src/lib/api-helpers.ts`

## Test plan

- [ ] Deploy the updated Worker (`cd docs && pnpm run deploy`)
- [ ] Open the StackBlitz demo: `https://stackblitz.com/github/hideokamoto/stripe-pwa-elements/tree/main/examples/stackblitz`
- [ ] Confirm "Using demo key: pk_test_xx…" appears in the key status field on load
- [ ] Click **Render** — `stripe-address-element` should mount without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CGKNy9dkYjb4aV98dzjHR

---
_Generated by [Claude Code](https://claude.ai/code/session_011CGKNy9dkYjb4aV98dzjHR)_